### PR TITLE
Add script for generating embeddings for modernbert variant

### DIFF
--- a/scripts/activate
+++ b/scripts/activate
@@ -6,10 +6,8 @@
 # Run with:
 #    source scripts/activate
 #
-
-SCRIPT_PARENT_ROOT=$(
-    dirname ${BASH_SOURCE[0]} | realpath $(cat -)
-)
+# don't use bash_source since it gets called from other scripts
+SCRIPT_PARENT_ROOT=$(dirname $(realpath ${BASH_SOURCE[0]}))
 
 # adds the scripts directory to the path
 PATH="$PATH:$SCRIPT_PARENT_ROOT"

--- a/scripts/sbatch/slurm-embed-large.sbatch
+++ b/scripts/sbatch/slurm-embed-large.sbatch
@@ -1,36 +1,37 @@
 #!/bin/bash
 #SBATCH --job-name=longeval-embed --account=paceship-dsgt_clef2025
-#SBATCH --nodes=1 --gres=gpu:V100:1 git --cpus-per-task=12 --mem-per-gpu=140G
+#SBATCH --nodes=1 --gres=gpu:V100:1 --cpus-per-task=6 --mem-per-gpu=64G
 #SBATCH --qos=embers -t120
 #SBATCH --output=Report-%j.out
 #SBATCH --mail-type=END,FAIL --mail-user=acmiyaguchi@gatech.edu
-#SBATCH --array=0-3%5
+#SBATCH --array=0-49%5
 
-set -eu
-export NO_REINSTALL=1
-source ~/clef/longeval-2025/scripts/activate
+set -xeu
+cd ~/scratch/longeval
+source .venv/bin/activate
+export PATH=$PATH:~/clef/longeval-2025/scripts
 
-set -x
 nproc
 free -h
 python -c "import torch; print(torch.cuda.is_available())"
 
 # start the nvidia monitoring job in the background using slurm job id
-NVIDIA_LOG_FILE=Report-${SLURM_JOB_ID}-nvidia-logs.ndjson
+NVIDIA_LOG_FILE=${SLURM_SUBMIT_DIR}/Report-${SLURM_JOB_ID}-nvidia-logs.ndjson
 nvidia-logs monitor $NVIDIA_LOG_FILE --interval 15 &
 nvidia_logs_pid=$!
 
 project_dir=/storage/coda1/p-dsgt_clef2025/0/shared/longeval
+scratch_dir=$(realpath ~/scratch/longeval)
 dataset=$1
 model_name=$2
-export PYSPARK_DRIVER_MEMORY=10g
-export PYSPARK_EXECUTOR_MEMORY=10g
+export PYSPARK_DRIVER_MEMORY=8g
+export PYSPARK_EXECUTOR_MEMORY=8g
 export SPARK_LOCAL_DIR=$TMPDIR/spark-tmp
 longeval etl embedding \
-    $project_dir/parquet/$dataset \
+    $scratch_dir/parquet/$dataset \
     $project_dir/embedding/${model_name/\//-}/$dataset \
     --model-name $model_name \
-    --cpu-count 12 \
+    --cpu-count 6 \
     --batch-size 1 \
     --num-sample-ids 50 \
     --sample-id $SLURM_ARRAY_TASK_ID

--- a/scripts/sbatch/slurm-embed.sbatch
+++ b/scripts/sbatch/slurm-embed.sbatch
@@ -19,13 +19,14 @@ nproc
 free -h
 python -c "import torch; print(torch.cuda.is_available())"
 
-project_dir=~/p-dsgt_clef2025-0/longeval
+project_dir=/storage/coda1/p-dsgt_clef2025/0/shared/longeval
+scratch_dir=$(realpath ~/scratch/longeval)
 dataset=$1
 model_name=$2
 export PYSPARK_DRIVER_MEMORY=28g
 export SPARK_LOCAL_DIR=$TMPDIR/spark-tmp
 longeval etl embedding \
-    $project_dir/parquet/$dataset \
+    $scratch_dir/parquet/$dataset \
     $project_dir/embedding/${model_name/\//-}/$dataset \
     --model-name $model_name \
     --cpu-count 4 \

--- a/scripts/sbatch/sync-scratch.sbatch
+++ b/scripts/sbatch/sync-scratch.sbatch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH --job-name=rsync --account=paceship-dsgt_clef2025
+#SBATCH -N1 -n1 --cpus-per-task=4 --mem-per-cpu=4G
+#SBATCH -t20 -qinferno -oReport-%j.out
+set -e
+
+project_dir=/storage/coda1/p-dsgt_clef2025/0/shared/longeval
+scratch_dir=$(realpath ~/scratch/longeval)
+# trim trailing slash
+prefix=${1%/}
+
+# exit if prefix doesn't exist
+if [ ! -d $project_dir/$prefix ]; then
+    echo "Directory $project_dir/$prefix does not exist"
+    exit 1
+fi
+
+# now copy directories from project into scratch
+rclone sync -v --progress --transfers 12 $project_dir/$prefix/ $scratch_dir/$prefix

--- a/scripts/slurm-embed
+++ b/scripts/slurm-embed
@@ -2,7 +2,7 @@
 from enum import Enum
 from pathlib import Path
 from subprocess import run
-
+import os
 import typer
 from typing_extensions import Annotated
 
@@ -33,7 +33,8 @@ def main(
         if model_name in ["all-MiniLM-L6-v2"]
         else "sbatch/slurm-embed-large.sbatch"
     )
-    root = Path("/storage/coda1/p-dsgt_clef2025/0/shared/longeval/parquet")
+    home = Path(os.environ["HOME"])
+    root = home / "shared/longeval/parquet"
     paths = sorted(
         [
             path.relative_to(root)

--- a/scripts/utils/slurm-venv.sh
+++ b/scripts/utils/slurm-venv.sh
@@ -34,7 +34,6 @@ fi
 
 # check for NO_REINSTALL flag
 if [[ -z ${NO_REINSTALL:-} ]]; then
-    uv pip install -r $MODULE_PATH/requirements.txt
     uv pip install -e $MODULE_PATH
 fi
 popd

--- a/user/acmiyaguchi/slurm-embed.sbatch
+++ b/user/acmiyaguchi/slurm-embed.sbatch
@@ -1,15 +1,9 @@
 #!/bin/bash
 #SBATCH --job-name=longeval-embed --account=paceship-dsgt_clef2025
-#SBATCH --nodes=1 --gres=gpu:V100:1 --cpus-per-task=12 --mem-per-gpu=140G
+#SBATCH --nodes=1 --gres=gpu:V100:1 --cpus-per-task=6 --mem-per-gpu=64G
 #SBATCH --qos=inferno -t120     # set qos=embers for free gpu jobs
 #SBATCH --output=Report-%j.out
-##SBATCH --mail-type=END,FAIL --mail-user=acmiyaguchi@gatech.edu
-##SBATCH --array=1,10,50
-# for parallel runs, we can do this for some parameter sweeps
-# these can be accessed in the script as $SLURM_ARRAY_TASK_ID
-
-set -eu
-export NO_REINSTALL=1
+##SBATCH --mail-type=END,FAIL --mail-user=acmiyaguchi@gatech.edu0
 source ~/clef/longeval-2025/scripts/activate
 
 set -x
@@ -23,7 +17,7 @@ NVIDIA_LOG_FILE=Report-${SLURM_JOB_ID}-nvidia-logs.ndjson
 nvidia-logs monitor $NVIDIA_LOG_FILE --interval 15 &
 nvidia_logs_pid=$!
 
-project_dir=/storage/coda1/p-dsgt_clef2025/0/shared/longeval
+scratch_dir=$(realpath ~/scratch/longeval)
 dataset=train/2023_01/English/Documents
 # model_name="all-MiniLM-L6-v2"
 # model_name="joe32140/ModernBERT-base-msmarco"
@@ -37,10 +31,10 @@ export SPARK_LOCAL_DIR=$TMPDIR/spark-tmp
 # this is a testing job and we want to make sure to always write new data.
 # The slurm job id is used to ensure that we don't overwrite data.
 longeval etl embedding \
-    $project_dir/parquet/$dataset \
-    ~/scratch/longeval/test/embedding/${model_name/\//-}/${SLURM_JOB_ID}/$dataset \
+    $scratch_dir/parquet/$dataset \
+    $scratch_dir/test/embedding/${model_name/\//-}/${SLURM_JOB_ID}/$dataset \
     --model-name $model_name \
-    --cpu-count 12 \
+    --cpu-count 6 \
     --batch-size 1 \
     --num-sample-ids 50 \
     --sample-id 0


### PR DESCRIPTION
This contains tuned scripts for launched modernbert.

```
# activate the environment. 
$ NO_REINSTALL=1 source scripts/activate

# run the script, by default it is a dry-run
$ slurm-embed

sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-test/2023_06/English/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch test/2023_06/English/Documents nomic-ai/modernbert-embed
sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-test/2023_06/French/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch test/2023_06/French/Documents nomic-ai/modernbert-embed
sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-test/2023_08/English/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch test/2023_08/English/Documents nomic-ai/modernbert-embed
sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-test/2023_08/French/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch test/2023_08/French/Documents nomic-ai/modernbert-embed
sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-train/2023_01/English/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch train/2023_01/English/Documents nomic-ai/modernbert-embed
sbatch --job-name=longeval-embed-nomic-ai/modernbert-embed-train/2023_01/French/Documents /storage/home/hcoda1/8/amiyaguchi3/clef/longeval-2025/scripts/sbatch/slurm-embed-large.sbatch train/2023_01/French/Documents nomic-ai/modernbert-embed
```

One of these gets run manually by copy and pasting. This will generate 50 jobs, each of which gets a report in the current directory.

![image](https://github.com/user-attachments/assets/9474e0c5-a6e5-4fec-969c-e52b68a78b7c)

```csv
pid,start,end,interval_count,min_used_memory_mb,max_used_memory_mb,avg_used_memory_mb,stddev_used_memory_mb,duration_sec
3509664,1739523619,1739525584,130,454,1658,1562.3538461538462,247.4364020250617,1965
3509668,1739523619,1739525584,130,454,2114,1776.676923076923,403.47433403255906,1965
3509672,1739523619,1739525584,130,454,1784,1538.5230769230768,317.10038552812773,1965
3509674,1739523619,1739525584,130,454,2282,1794.7692307692307,522.0732898512887,1965
3509675,1739523619,1739525584,130,454,2092,1825.8,346.16641156548394,1965
3509676,1739523619,1739525584,130,454,1502,1437.553846153846,202.70760480827542,1965
```

These are two examples of the files that get generated from that run.

