### PR TITLE
Allow log sweeps into non-default directory

### DIFF
--- a/scripts/sweep-logs
+++ b/scripts/sweep-logs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set +eux
-mkdir -p logs
-mv Report* logs/
+dir=${1:-logs}
+mkdir -p $dir
+mv Report* $dir/


### PR DESCRIPTION
This is really useful for the modernbert stuff in #19 which generates a bunch of files.