### PR TITLE
Extend LDA K-selection sweep to K=2..20

### DIFF
--- a/longeval/etl/lda/workflow.py
+++ b/longeval/etl/lda/workflow.py
@@ -647,9 +647,9 @@ class TrainLDAModel(luigi.Task):
 
 
 class TrainLDASweep(luigi.Task):
-    """Fit every K in one Spark session via ``LDA.fitMultiple``.
+    """Fit missing K values in one Spark session via ``LDA.fitMultiple``.
 
-    Reads + caches ``features.parquet`` exactly once, then fits all
+    Reads + caches ``features.parquet`` exactly once, then fits the missing
     ``k_values`` against that single cached DataFrame, writing each model
     to ``<output_path>/k{K}/lda_model`` with a per-K ``_train_config.json``
     stamp **byte-identical** to what a per-K ``TrainLDAModel`` would write.
@@ -713,15 +713,18 @@ class TrainLDASweep(luigi.Task):
             "preprocess_hash": _preprocess_hash(self),
         }
 
+    def _k_complete(self, k):
+        return os.path.exists(
+            os.path.join(self._k_dir(k), "lda_model")
+        ) and _stamp_matches(
+            self._train_config_path(k), self._train_config_dict(k)
+        )
+
+    def _missing_k_values(self):
+        return [k for k in self.k_values if not self._k_complete(k)]
+
     def complete(self):
-        for k in self.k_values:
-            if not os.path.exists(os.path.join(self._k_dir(k), "lda_model")):
-                return False
-            if not _stamp_matches(
-                self._train_config_path(k), self._train_config_dict(k)
-            ):
-                return False
-        return True
+        return not self._missing_k_values()
 
     def requires(self):
         return BuildFeatures(
@@ -739,11 +742,18 @@ class TrainLDASweep(luigi.Task):
         )
 
     def run(self):
+        # Guard before opening Spark so a run() called directly on an
+        # already-complete task stays a cheap no-op.
+        missing_ks = self._missing_k_values()
+        if not missing_ks:
+            print("All K models already complete; skipping fitMultiple.")
+            return
+
         with spark_resource() as spark:
             spark.sparkContext.setLogLevel("ERROR")
 
             # Read + cache the (multi-GB at full slice) feature matrix
-            # ONCE; every K's fit reuses this cache instead of the old
+            # ONCE; every missing K's fit reuses this cache instead of the old
             # per-K parquet re-read + fresh JVM.
             features = spark.read.parquet(
                 os.path.join(self._preprocess_path(), "features.parquet")
@@ -751,7 +761,7 @@ class TrainLDASweep(luigi.Task):
             try:
                 features.count()
                 lda = _build_lda(
-                    k=int(self.k_values[0]),
+                    k=int(missing_ks[0]),
                     max_iter=self.max_iter,
                     seed=self.seed,
                     learning_offset=self.learning_offset,
@@ -759,9 +769,9 @@ class TrainLDASweep(luigi.Task):
                     subsampling_rate=self.subsampling_rate,
                     optimize_doc_concentration=self.optimize_doc_concentration,
                 )
-                param_maps = [{lda.k: int(k)} for k in self.k_values]
+                param_maps = [{lda.k: int(k)} for k in missing_ks]
                 for index, model in lda.fitMultiple(features, param_maps):
-                    k = int(self.k_values[index])
+                    k = int(missing_ks[index])
                     k_dir = self._k_dir(k)
                     os.makedirs(k_dir, exist_ok=True)
                     model.write().overwrite().save(
@@ -902,11 +912,11 @@ class RunLDAInference(luigi.Task):
 
 
 class InferLDASweep(luigi.Task):
-    """Inference analogue of ``TrainLDASweep``: score every K's model in
+    """Inference analogue of ``TrainLDASweep``: score missing K models in
     one Spark session.
 
     Loads ``vector_model`` and caches ``features.parquet`` once, then for
-    each K loads ``k{K}/lda_model``, writes
+    each missing K loads ``k{K}/lda_model``, writes
     ``k{K}/docTopicDistribution_lda.parquet`` + ``topicWords_lda.txt`` and
     a per-K ``_inference_config.json`` **byte-identical** to what a per-K
     ``RunLDAInference`` would write. That identity lets the per-K
@@ -960,18 +970,17 @@ class InferLDASweep(luigi.Task):
             "preprocess_hash": _preprocess_hash(self),
         }
 
+    def _k_complete(self, k):
+        out = os.path.join(self._k_dir(k), "docTopicDistribution_lda.parquet")
+        return os.path.exists(out) and _stamp_matches(
+            self._infer_config_path(k), self._infer_config_dict(k)
+        )
+
+    def _missing_k_values(self):
+        return [k for k in self.k_values if not self._k_complete(k)]
+
     def complete(self):
-        for k in self.k_values:
-            out = os.path.join(
-                self._k_dir(k), "docTopicDistribution_lda.parquet"
-            )
-            if not os.path.exists(out):
-                return False
-            if not _stamp_matches(
-                self._infer_config_path(k), self._infer_config_dict(k)
-            ):
-                return False
-        return True
+        return not self._missing_k_values()
 
     def requires(self):
         return TrainLDASweep(
@@ -997,6 +1006,13 @@ class InferLDASweep(luigi.Task):
         )
 
     def run(self):
+        # Guard before opening Spark so a run() called directly on an
+        # already-complete task stays a cheap no-op.
+        missing_ks = self._missing_k_values()
+        if not missing_ks:
+            print("All K inference already complete; skipping.")
+            return
+
         with spark_resource() as spark:
             spark.sparkContext.setLogLevel("ERROR")
             preprocess = self._preprocess_path()
@@ -1007,14 +1023,14 @@ class InferLDASweep(luigi.Task):
             if not vocab:
                 raise ValueError("Empty CountVectorizer vocabulary.")
 
-            # Cache the feature matrix once; every K's transform reuses
-            # it instead of the old per-K parquet re-read + fresh JVM.
+            # Cache the feature matrix once; every missing K's transform
+            # reuses it instead of the old per-K parquet re-read + fresh JVM.
             features = spark.read.parquet(
                 os.path.join(preprocess, "features.parquet")
             ).cache()
             try:
                 features.count()
-                for k in self.k_values:
+                for k in missing_ks:
                     k = int(k)
                     k_dir = self._k_dir(k)
                     os.makedirs(k_dir, exist_ok=True)
@@ -1917,9 +1933,9 @@ def sweep_main(
         k_values: Annotated[
             str,
             typer.Argument(
-                help="Comma-separated K values to sweep, e.g. '2,3,5,10,20,30,40,80,160'"
+                help="Comma-separated K values to sweep, e.g. '2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20'"
             ),
-        ] = "2,3,5,10,20,30,40,80,160",
+        ] = "2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
         input_path: Annotated[
             str, typer.Argument(help="Input root directory")
         ] = "/mnt/data/longeval",
@@ -2019,11 +2035,11 @@ def topic_proportions_main(
         k_values: Annotated[
             str,
             typer.Argument(
-                help="Comma-separated K values, e.g. '5,10,20'. Each must "
+                help="Comma-separated K values, e.g. '2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20'. Each must "
                 "already have a completed docTopicDistribution under "
                 "<output_path>/k<K>/ (run lda-sweep first)."
             ),
-        ] = "5,10,20",
+        ] = "2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
         input_path: Annotated[
             str, typer.Argument(help="Corpus root (the lda-sweep input_path)")
         ] = "/mnt/data/longeval",

--- a/tests/lda_tests/test_workflow_sweep.py
+++ b/tests/lda_tests/test_workflow_sweep.py
@@ -286,6 +286,58 @@ def test_sweep_stamp_is_byte_identical_to_per_k_train():
     assert sweep._train_config_dict(3) == per_k._config_dict()
 
 
+def _write_json(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(payload, f)
+
+
+def test_train_sweep_missing_k_values_are_incremental(tmp_path):
+    root = str(tmp_path / "sweep")
+    sweep = TrainLDASweep(
+        input_path="/in",
+        output_path=root,
+        preprocess_path=str(tmp_path / "preprocess"),
+        k_values=[2, 3, 5],
+    )
+    assert list(sweep._missing_k_values()) == [2, 3, 5]
+
+    os.makedirs(os.path.join(root, "k2", "lda_model"))
+    _write_json(sweep._train_config_path(2), sweep._train_config_dict(2))
+    assert list(sweep._missing_k_values()) == [3, 5]
+
+    os.makedirs(os.path.join(root, "k3", "lda_model"))
+    _write_json(sweep._train_config_path(3), {"num_topics": 999})
+    assert list(sweep._missing_k_values()) == [3, 5]
+
+    _write_json(sweep._train_config_path(3), sweep._train_config_dict(3))
+    os.makedirs(os.path.join(root, "k5", "lda_model"))
+    _write_json(sweep._train_config_path(5), sweep._train_config_dict(5))
+    assert sweep.complete() is True
+
+
+def test_infer_sweep_missing_k_values_are_incremental(tmp_path):
+    root = str(tmp_path / "sweep")
+    sweep = InferLDASweep(
+        input_path="/in",
+        output_path=root,
+        preprocess_path=str(tmp_path / "preprocess"),
+        k_values=[2, 3],
+    )
+    assert list(sweep._missing_k_values()) == [2, 3]
+
+    os.makedirs(os.path.join(root, "k2", "docTopicDistribution_lda.parquet"))
+    _write_json(sweep._infer_config_path(2), sweep._infer_config_dict(2))
+    assert list(sweep._missing_k_values()) == [3]
+
+    os.makedirs(os.path.join(root, "k3", "docTopicDistribution_lda.parquet"))
+    _write_json(sweep._infer_config_path(3), {"task": "stale"})
+    assert list(sweep._missing_k_values()) == [3]
+
+    _write_json(sweep._infer_config_path(3), sweep._infer_config_dict(3))
+    assert sweep.complete() is True
+
+
 # ---------------------------------------------------------------------------
 # Spark end-to-end
 # ---------------------------------------------------------------------------

--- a/user/anthony/20260527-lda-k2-20-sweep-scan.md
+++ b/user/anthony/20260527-lda-k2-20-sweep-scan.md
@@ -1,0 +1,168 @@
+# LDA K=2..20 sweep scan
+
+Date: 2026-05-27
+
+## Context
+
+Issue #36 requested extending the LDA K-selection sweep to a single comparable curve over every integer K from 2 through 20.
+
+A draft PR was opened with the code changes:
+
+- PR: https://github.com/dsgt-arc/longeval-2025/pull/39
+- Branch: `issue-36-lda-k-sweep`
+- Commit: `dc6823c Extend LDA K sweep to 2..20`
+
+## Code changes
+
+- Default `lda-sweep` K grid changed to `2,3,4,...,20`.
+- Default `lda-topic-proportions` K grid changed to match.
+- `TrainLDASweep` now checks per-K model + `_train_config.json` stamp and only fits missing/stale K values.
+- `InferLDASweep` now checks per-K `docTopicDistribution_lda.parquet` + `_inference_config.json` stamp and only scores missing/stale K values.
+- Regression tests added for missing-K detection.
+
+Validation before the long run:
+
+```text
+uv run ruff check longeval/etl/lda/workflow.py tests/lda_tests/test_workflow_sweep.py
+uv run pytest tests/lda_tests/test_workflow_sweep.py -q
+# 21 passed
+```
+
+## Runtime setup
+
+To avoid mutating the existing K=2..10 sweep root, a fresh root was created:
+
+```text
+/mnt/data/tmp/lda-k2-20-sweep
+```
+
+It was seeded by hardlinking from:
+
+```text
+/mnt/data/tmp/lda-k2-10-sweep
+```
+
+Seeded items:
+
+```text
+preprocess/
+k2/ ... k10/
+```
+
+Input corpus:
+
+```text
+/mnt/data/tmp/longeval-train-parquet
+```
+
+Important parameters used to preserve comparability with the K=2..10 run:
+
+```text
+--date all
+--sample-fraction 1.0
+```
+
+Preflight status before launch:
+
+```text
+mine phrases complete True
+build features complete True
+train missing [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+infer missing [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+aggregate sweep complete False
+aggregate topic proportions complete False
+```
+
+Launch command:
+
+```bash
+PYSPARK_DRIVER_CORES=8 \
+PYSPARK_DRIVER_MEMORY=36g \
+SPARK_LOCAL_IP=127.0.0.1 \
+uv run longeval etl lda-sweep \
+  "2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20" \
+  /mnt/data/tmp/longeval-train-parquet \
+  /mnt/data/tmp/lda-k2-20-sweep \
+  --date all \
+  --sample-fraction 1.0
+```
+
+Log:
+
+```text
+artifacts/logs/lda-sweep-k2-20-20260526-232443.log
+```
+
+Exit status:
+
+```text
+0
+```
+
+Completion checks after the run:
+
+```text
+AggregateLDASweep.complete True
+AggregateTopicProportions.complete True
+```
+
+Root outputs:
+
+```text
+/mnt/data/tmp/lda-k2-20-sweep/sweep_coherence.parquet
+/mnt/data/tmp/lda-k2-20-sweep/topic_proportions.parquet
+/mnt/data/tmp/lda-k2-20-sweep/topic_drift.parquet
+```
+
+## K-selection results
+
+Metric used here:
+
+```text
+coherence_diversity = mean_npmi * topic_diversity
+```
+
+Full curve:
+
+| K | mean NPMI | topic diversity | coherence diversity | n docs |
+|---:|---:|---:|---:|---:|
+| 2 | 0.244944 | 1.000000 | 0.244944 | 16,263,471 |
+| 3 | 0.329847 | 1.000000 | 0.329847 | 16,263,471 |
+| 4 | 0.350851 | 1.000000 | 0.350851 | 16,263,471 |
+| 5 | 0.316523 | 0.980000 | 0.310193 | 16,263,471 |
+| 6 | 0.224074 | 0.966667 | 0.216604 | 16,263,471 |
+| 7 | 0.211098 | 0.971429 | 0.205066 | 16,263,471 |
+| 8 | 0.232861 | 0.962500 | 0.224128 | 16,263,471 |
+| 9 | 0.273287 | 0.955556 | 0.261141 | 16,263,471 |
+| 10 | 0.271099 | 0.950000 | 0.257544 | 16,263,471 |
+| 11 | 0.239178 | 0.927273 | 0.221784 | 16,263,471 |
+| 12 | 0.256344 | 0.916667 | 0.234982 | 16,263,471 |
+| 13 | 0.341019 | 0.930769 | 0.317410 | 16,263,471 |
+| 14 | 0.339860 | 0.914286 | 0.310729 | 16,263,471 |
+| 15 | 0.319553 | 0.940000 | 0.300380 | 16,263,471 |
+| 16 | 0.318102 | 0.956250 | 0.304185 | 16,263,471 |
+| 17 | 0.297645 | 0.941176 | 0.280137 | 16,263,471 |
+| 18 | 0.278847 | 0.938889 | 0.261807 | 16,263,471 |
+| 19 | 0.355041 | 0.926316 | 0.328880 | 16,263,471 |
+| 20 | 0.347640 | 0.930000 | 0.323305 | 16,263,471 |
+
+Best K by `coherence_diversity`:
+
+```text
+K=4, coherence_diversity=0.350851
+```
+
+Best new points above K=10:
+
+```text
+K=19: coherence_diversity=0.328880
+K=20: coherence_diversity=0.323305
+K=13: coherence_diversity=0.317410
+```
+
+Conclusion: extending the comparable curve to K=2..20 did not change the winner under the coherence-diversity metric. K=4 remains the best choice.
+
+## Notes on coherence
+
+The coherence metric is doc-level NPMI over topic top words. A topic scores higher when its top words co-occur in documents more often than chance. `topic_diversity` penalizes duplicated/reused top words across topics. `coherence_diversity` combines these into one K-selection score.
+

--- a/user/anthony/20260527-lda-k200-worklog.md
+++ b/user/anthony/20260527-lda-k200-worklog.md
@@ -1,0 +1,312 @@
+# LDA K=200 converged — worklog
+
+Date: 2026-05-27
+
+## Goal
+
+Train a converged K=200 LDA model for topic-granularity exploration: see
+how the fine-topic story compares to K=4 (CLEF paper headline) and K=20
+(granular companion), and whether the Dec-2022 document regime change
+remains a single mass swap or diffuses across many fine registers.
+
+## TL;DR — one-liners
+
+1. **K=200 model trained successfully under the converged recipe**
+   (`maxIter=50`, `learning_offset=1024`, `subsampling_rate=0.05`,
+   `optimize_doc_concentration=True`, `seed=42`, `sample_fraction=1.0`,
+   `date=all`). Pooled 9-slice corpus, 16,263,471 docs. Wall-clock ~7 h
+   for the LDA fit; pipeline end-to-end ~10 h.
+
+2. **Coherence/diversity trades exactly as the K-selection curve predicts.**
+   mean NPMI 0.259 (vs 0.354 K=4, 0.372 K=20), diversity 0.869 (vs 1.0/0.95),
+   coh×div 0.225 (vs 0.354/0.354). K=200 is well past the optimum on the
+   combined metric.
+
+3. **The granularity split is real, not noise.** 25/200 topics have
+   NPMI > 0.5 (tight fine registers) — *more* than K=20's whole-count (5).
+   17/200 have negative NPMI (genuine over-split junk quarantine — analogous
+   to K=4's T2 spam register, but at ~8.5% of topics it's a distinct band).
+   Tightest single topic gets *tighter* than K=20: max NPMI 0.986 vs 0.949.
+
+4. **Dec-2022 mass swap *diffuses* at K=200.** K=4 T0↑/T3↓ was a discrete
+   ~5 pp step. K=20 localised it to T8 (+3 pp) / T16 (−4.8 pp). At K=200, no
+   single topic moves more than 1.4 pp first→last train slice, but cumulative
+   |Δ| grows (0.113 K=4 → 0.209 K=20 → 0.251 K=200). The same crawl shift
+   gets redistributed across many fine registers; mass conservation holds
+   to 5e-5.
+
+5. **EvaluateLDAModel Python worker crashed on first attempt, succeeded on
+   Luigi retry — no code change, no config change.** Marginal/non-deterministic
+   memory pressure in the `doc_level_npmi_coherence` UDF at K=200 vocab union
+   (~2 k words). The cache was on a warmer Spark state during attempt 1;
+   attempt 2 ran after Infer drained it. **The model and coherence are valid.**
+
+6. **Held-out 15-slice drift confirms K=20 saturation.** Pre→post Dec-2022
+   pooled L1 mass shift is **0.2115** at K=200 — essentially identical to
+   K=20's 0.2011, both ~2× K=4's 0.106. The Dec-2022 break has a fixed
+   structural magnitude that K=20 already captures; K=200 only redistributes
+   the same mass over finer registers. Test-window plateau (2023-03..08) holds
+   sharply: max per-topic std 0.00093, median std 3e-5, median CV 1.1 % — same
+   flat-after-step shape as K=4/K=20.
+
+7. **Register pattern of the top heldout movers is paper-decisive.**
+   *Down-movers* (losing mass post-Dec-2022) are uniformly **substantive
+   French content**: T47 generic French narrative prose / fillers (Δ −0.013),
+   T122 climate/sustainable-development discourse (−0.011), T16 history /
+   literature (−0.009), T44 politico-economic transitions / Borne-era policy
+   (−0.005), T164 French film/audiovisual credits (−0.005), T121 French
+   cultural events / festivals (−0.004), T42 French given-name biographical
+   listings (−0.005). *Up-movers* are uniformly **English-language content +
+   commerce/booking boilerplate**: T139 EN hotel/travel commerce (+0.006),
+   T84 EN country/island geographic enumeration (+0.006), T198 EN
+   forum/blog prose (+0.006), T89 EN business/government news (+0.005),
+   T40 EN medical/pharma (+0.005), T48 EN narrative/biographical (+0.005),
+   T145 FR hotel-booking boilerplate (+0.005), T185 EN web-form/cookie
+   boilerplate (+0.004). **Substitution of substantive French prose with
+   English-language web content + commerce/booking boilerplate** — a
+   crawl/extraction regime change, confirming K=20's reading at fine
+   resolution.
+
+## Paths / corpus
+
+| What | Where |
+|---|---|
+| Converged K=200 root | `/mnt/data/tmp/lda-k200-converged/` |
+| Hardlinked preprocess (inode-shared from k4-converged) | `lda-k200-converged/preprocess/` |
+| Trained model | `lda-k200-converged/k200/lda_model` (31 MB) |
+| Top-100 words / topic | `lda-k200-converged/k200/topicWords_lda.txt` (232 KB) |
+| Doc-topic distribution (200 cols × 16.26 M rows) | `lda-k200-converged/k200/docTopicDistribution_lda.parquet` (5.8 GB) |
+| Coherence | `lda-k200-converged/k200/coherence.parquet` |
+| Topic proportions (per-K, slice-aggregated) | `lda-k200-converged/k200/topicProportions.parquet` |
+| Topic proportions (root aggregate) | `lda-k200-converged/topic_proportions.parquet` |
+| Topic drift (root aggregate, n_slices=9 train) | `lda-k200-converged/topic_drift.parquet` |
+| Sweep coherence | `lda-k200-converged/sweep_coherence.parquet` |
+| Held-out 15-slice features | `lda-k200-converged/heldout/features.parquet` |
+| Held-out 15-slice inference (40 parts, 3.2 GB) | `lda-k200-converged/heldout/k200/docTopicDistribution_lda.parquet` |
+| Held-out 15-slice mean θ | `lda-k200-converged/heldout/topic_proportions_15slice.parquet` |
+| Held-out 15-slice drift | `lda-k200-converged/heldout/topic_drift_15slice.parquet` |
+| Train log | `/mnt/data/tmp/lda-k200-converged.log` |
+| Held-out log | `/mnt/data/tmp/lda-k200-converged-heldout.log` |
+
+Train corpus: `/mnt/data/tmp/longeval-train-parquet` (9 slice, 16,263,471).
+Test corpus: `/mnt/data/tmp/longeval-test-parquet` (6 slice, 10,909,437).
+
+NB: hardlinked from `lda-k4-converged/preprocess/` (`preprocess_hash`
+`7580d2af…`, `phrases_hash` `978d78f5…`), so MinePhrases/BuildFeatures
+short-circuited and the K=4/K=20/K=200 trio share identical vocab + phrases
+— directly comparable.
+
+## Per-K comparison (the headline table)
+
+All values computed on the same converged recipe, same preprocess, same
+9-slice pooled corpus.
+
+| metric | K=4 | K=20 | K=200 |
+|---|---:|---:|---:|
+| mean NPMI | 0.3542 | **0.3723** | 0.2586 |
+| topic diversity | 1.0000 | 0.9500 | 0.8690 |
+| coherence × diversity | **0.3542** | 0.3536 | 0.2247 |
+| median per-topic NPMI | 0.3224 | 0.3052 | 0.2272 |
+| min per-topic NPMI | 0.1429 | 0.0146 | −0.1157 |
+| max per-topic NPMI | 0.6292 | 0.9486 | **0.9863** |
+| topics with NPMI < 0 | 0 | 0 | **17** (8.5 %) |
+| topics with NPMI > 0.5 | 1 | 5 | **25** (12.5 %) |
+
+Reads:
+- **K=20 wins raw NPMI**, K=4 wins diversity (perfect 1.0); the *combined*
+  metric ties — K=4 is the marginal optimum (worklog 20260518). K=200 falls
+  off both axes.
+- **Tightest specialists keep getting tighter as K grows** (0.63 → 0.95 → 0.99).
+- **Junk quarantine emerges as a band, not a single topic.** K=4's pharma-spam
+  T2 (NPMI 0.30 — coherent because spam vocabulary is repetitive) becomes
+  17 fine quarantine topics at K=200, several with negative NPMI.
+
+## Train-side drift comparison (delta first→last train slice)
+
+| metric | K=4 | K=20 | K=200 |
+|---|---:|---:|---:|
+| topics with \|Δ\| > 5 pp | 1 | 1 | **0** |
+| topics with \|Δ\| > 3 pp | 2 | 2 | **0** |
+| topics with \|Δ\| > 1 pp | 2 | 8 | **3** |
+| max \|Δ\| (single topic) | 0.0543 | 0.0528 | **0.0140** |
+| sum \|Δ\| (total churn) | 0.1130 | 0.2094 | **0.2514** |
+| mass conservation Σ Δ | ~0 | ~0 | −0.00005 |
+
+**Interpretation.** The Dec-2022 step is a single sharp event in the data,
+not 200 small ones. At low K the model has nowhere to put it but one or two
+macro-registers — K=4 forces it into T0↑/T3↓ (±5 pp); K=20 lets it localise to
+T8/T16 (still ±3–5 pp). At K=200 the event spreads across many fine
+sub-registers and **no single topic carries the full step** — biggest mover
+is topic 47 at −1.4 pp. Cumulative drift mass keeps rising because fine
+topics each pick up a fragment, but every fragment is small.
+
+Top movers (K=200, train-side first→last slice):
+
+```
+ topic  first_θ  last_θ      Δ   mean_θ   std_θ
+   47   0.0544  0.0403  −0.0140  0.0490  0.0064
+  122   0.0281  0.0163  −0.0118  0.0238  0.0053
+   16   0.0346  0.0243  −0.0103  0.0307  0.0045
+  164   0.0085  0.0001  −0.0084  0.0029  0.0039
+  145   0.0008  0.0084  +0.0077  0.0049  0.0037
+  139   0.0122  0.0188  +0.0066  0.0142  0.0032
+   40   0.0127  0.0191  +0.0064  0.0152  0.0027
+   84   0.0048  0.0107  +0.0059  0.0066  0.0029
+```
+
+These movers should — by the K-coarsening lineage in the K4×K20 attribution
+(worklog 20260519) — decompose roughly into the K=20-T8 (EN web prose) and
+K=20-T16 (FR substantive prose) groups that K=4 surfaces as T0/T3. A formal
+K4×K200 / K20×K200 attribution crosstab would confirm. Not yet done.
+
+## Topic-words sanity check (small spot-read)
+
+```
+Topic   0:  photo, paris, art, adult_adult, image, photographie, musée, lycée,
+            collection, archives, …            ← Paris photo/art/museum register
+Topic   1:  communauté_communes, conseil_communautaire, commune,
+            collectivité_territoriale, communauté_agglomération, …, syndicat_mixte
+                                                ← French local-government / intercommunalité
+```
+
+`topicWords_lda.txt` skim shows coherent fine registers (Paris-art, FR-admin,
+…) coexisting with the over-split tail. A Thai bigram `จาก_เป็น` survives
+deep in one topic — the vocab tail surfacing at K=200, expected.
+
+## EvaluateLDAModel crash — what we know
+
+- **First attempt FAILED** at `restricted.count()` (`coherence.py`, stage 8
+  task 17). Spark JVM healthy (`-Xmx40g`, ~44 GiB RSS, no kernel OOM in
+  `journalctl`). Python worker died with `Connection reset` — i.e. the
+  worker process closed the socket unexpectedly. **No Python-side traceback
+  was captured because `spark.python.worker.faulthandler.enabled` was not
+  set** (the Spark error itself names this flag in its message).
+- **Retried by Luigi automatically** (same task hash `…2b7b171167`), succeeded.
+  No config or code change between attempts.
+- **Differentiating condition:** attempt 1 ran with the cached preprocess /
+  feature DataFrames still warm in Spark memory after Train; attempt 2 ran
+  after Infer had drained that state. Combined with mid-50 GiB system memory
+  pressure (62 GiB total, swap in use at ~6.7 GiB), the most plausible cause
+  is **marginal Python worker memory pressure** — not a fundamental
+  K=200-specific UDF break.
+- **Coherence numbers are valid** — the second attempt ran the full UDF chain
+  to completion against the full 16.26 M docs; `n_docs` in the parquet matches.
+
+Prophylactic for future K≥200 runs:
+```
+--conf spark.python.worker.faulthandler.enabled=true
+--conf spark.executor.pyspark.memory=2g
+--conf spark.master='local[4]'      # halve Python-side parallelism
+--conf spark.sql.shuffle.partitions=400
+```
+These weren't needed *this* time, but they would give a real Python
+traceback on the next marginal crash and cap worker memory cleanly.
+Coherence UDF (`coherence.py:67-148`) is shuffle-bounded by needed pairs
+(~9 k at K=200) — the algorithm is sound; the failure mode is system
+pressure, not scaling.
+
+## Verification log
+
+- Hardlink preprocess reuse: `_config.json` inode-identical to
+  `lda-k4-converged/preprocess/_config.json` (inode 46273778); BuildFeatures
+  marked DONE immediately on Luigi schedule. ✅
+- `_train_config.json` matches converged recipe (maxIter=50, offset=1024.0,
+  decay=0.51, subsampling=0.05, seed=42, optimize_doc_concentration=True). ✅
+- Doc-weighted mass via per-topic mean θ sums to 1.0 across 200 topics. ✅
+- `coherence.parquet` `n_docs` = 16,263,471 — full pooled corpus, no
+  sub-sampling. ✅
+- Drift mass conservation Σ Δ first→last = −4.9e-5 across 200 topics. ✅
+- Luigi final summary: *"This progress looks :) because there were failed
+  tasks but they all succeeded in a retry"* — bg job exit rc=0. ✅
+
+## Held-out 15-slice drift — results
+
+Wall clock: 2 h 00 m (kickoff 2026-05-27 23:29 → finish 2026-05-28 01:29).
+Inference Stage 20 hit a swap-pressure cliff around 16/40 (driver RSS 60 GB,
+swap 12 → 24 GiB; ~14 min stall) but cleared on its own once γ caches were
+released — no intervention, no errors, no kernel OOM-kill. All 40 parts
+committed at 01:24; aggregates landed 01:27 (`topic_proportions_15slice`) and
+01:29 (`topic_drift_15slice`). `heldout/k200/lda_model` absent — inference-only,
+no retrain (as designed). bg exit rc=0.
+
+### Held-out drift — per-K comparison
+
+| metric | K=4 | K=20 | **K=200** |
+|---|---:|---:|---:|
+| pre→post Dec-2022 pooled L1 mass shift (Σ \|Δ\|) | 0.106 | 0.2011 | **0.2115** |
+| first→last slice cumulative L1 (Σ \|Δ\|) | — | — | **0.2431** |
+| max single-topic \|first→last Δ\| | T3 0.054 | T16 0.048 | **T47 0.013** |
+| test-window (2023-03..08) max std | flat | flat | **0.00093** |
+| test-window median per-topic CV | <1 % | <1 % | **1.1 %** |
+| top-15 movers' share of pre/post shift | — | — | ~45 % (0.094 / 0.2115) |
+
+**Reads.**
+- L1 mass shift saturates between K=20 and K=200 (0.20 → 0.21). The Dec-2022
+  break has a fixed structural magnitude that K=20 already captures; K=200
+  only smears it across finer registers. **Supports K=20 as the right
+  granularity for the drift writeup** — K=200 is corroborative, not additive.
+- Step-dominated: first→last cumulative (0.243) is only ~15 % larger than the
+  pre/post pooled (0.212), so the shift is concentrated at the Dec-2022
+  boundary, not a continuous drift through 2023.
+- Plateau holds at K=200 — same flat-after-step shape as K=4/K=20 across the
+  test window; no decay, no reversion.
+
+### Held-out drift — top movers (pre vs post Dec-2022 pooled means)
+
+| topic | Δ | first 2022-06 | last 2023-08 | register (top words) |
+|---|---:|---:|---:|---|
+| **T47**  | **−0.0125** | 0.0544 | 0.0416 | FR generic narrative prose / fillers (peut_être, quelqu_chose, faut, alors, dit, vie, dire, beaucoup) |
+| **T122** | **−0.0111** | 0.0281 | 0.0169 | climate / sustainable development (chang_climat, develop_durabl, nation_unie, environ, polit) |
+| **T16**  | **−0.0089** | 0.0346 | 0.0254 | FR history / literature (histoir, livr, auteu, siecl, guer, dieu, roman, francai) |
+| **T44**  | **−0.0047** | 0.0193 | 0.0150 | FR politico-economic transitions (projet, trans_ecolog, elisabeth_born, trans_energet, econom) |
+| **T164** | **−0.0042** | 0.0085 | 0.0001 | FR film / audiovisual credits (jean, production, catalogu_audiovisuel, francofol_rochel) |
+| **T121** | **−0.0040** | 0.0198 | 0.0156 | FR cultural events / festivals (musiqu, artist, spectacl, festival, theatr, concert) |
+| **T42**  | **−0.0043** | 0.0193 | 0.0150 | FR given-name biographical listings (jean, pier, mar, michel, claud) |
+| **T139** | **+0.0064** | 0.0122 | 0.0178 | EN hotel / travel commerce (pric, home, room, sale, park, hotel, travel, review) |
+| **T84**  | **+0.0062** | 0.0048 | 0.0107 | EN country / island geographic enumeration (island, virgin_island, cayman_island, falkland_island) |
+| **T198** | **+0.0061** | — | — | EN forum / blog prose (like, one, get, would, post, know, think, want) |
+| **T89**  | **+0.0054** | — | — | EN business / government news (stat, year, said, president, government, busines, manag) |
+| **T40**  | **+0.0055** | 0.0127 | 0.0183 | EN medical / pharma (may, side_efect, patient, cell, treatment, diseas, drug, canc) |
+| **T48**  | **+0.0045** | — | — | EN narrative / biographical (year_old, life, said, man, war, book) |
+| **T145** | **+0.0052** | 0.0008 | 0.0085 | FR hotel-booking boilerplate (centr_vile, anul_gratuit, hotel, period_incertitud, recomandon_reserv) |
+| **T185** | **+0.0044** | — | — | EN web-form / cookie boilerplate (email_adres, privacy_policy, cok, personal_data, pasword) |
+
+**Pattern.** Down-movers are uniformly **substantive French content** —
+narrative prose, history, climate/sustainability discourse, politico-economic
+editorial, film credits, cultural events, biographical listings. Up-movers are
+uniformly **English-language web content + commerce/booking boilerplate** —
+English forum prose, English geographic/biographical/business news, English
+medical, plus French and English commerce/booking boilerplate. **Substitution
+of substantive French prose with English-language web content + boilerplate**
+— exactly the K=20 finding at finer resolution; **a crawl/extraction regime
+change**, not a language-mix shift (the corpus is 100 % French-labelled
+throughout — see `20260519-lda-k4-worklog.md` Finding #2).
+
+## Open / next
+
+1. **K4×K200 / K20×K200 attribution crosstabs.** Decompose the K=4 T0/T3
+   step and the K=20 T8/T16 step into K=200 fine sub-registers — the
+   companion to `20260519-lda-k4xk20-attribution.md`. Useful but optional
+   given that K=20 already saturates the L1 mass shift (0.20 vs K=200 0.21).
+2. **Apply the prophylactic Spark config to the next K≥100 run.** Cheap
+   insurance against the Python-worker marginal-crash mode (Eval) and the
+   driver-RSS-into-swap mode (heldout Stage 20 stall): drop driver memory
+   back to 32–36 g and/or `local[4]` for K≥200.
+3. **Inspect `topicWords_lda.txt` end-to-end.** 200 fine registers — likely
+   ~150 substantive + ~30 junk (the 17 NPMI<0 + neighbors) + a few
+   boilerplate/cookie variants. Naming exercise out of scope here unless
+   needed downstream.
+4. **Archive.** Held-out drift validated the model and the substitution
+   pattern corroborates K=20 — paper-relevant as a granularity-saturation
+   anchor. Mint `longeval-lda-k200-converged-archive` (matching the K=4/K=20
+   archive pattern: model + vector_model + phrases + all parquets +
+   SHA256SUMS + MANIFEST.md), then push to GCS.
+
+## Lineage
+
+- Companion to `20260518-lda-k-selection.md` (K-selection curve, K=2..10)
+  and `20260519-lda-k4-worklog.md` / `20260519-lda-k4xk20-attribution.md`
+  (the K=4 paper model and its K=20 refinement).
+- Sweep grid `K=2..20` extended via PR #39 (`20260527-lda-k2-20-sweep-scan.md`)
+  is not yet finished as of this writing; K=200 sits as a standalone
+  granularity anchor outside that grid.

--- a/user/anthony/20260528-corpus-diagnostics-numbers.md
+++ b/user/anthony/20260528-corpus-diagnostics-numbers.md
@@ -14,6 +14,8 @@ top-3 boilerplate-hash counts per slice.
 
 Source: `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet`,
 ranked by `mean_theta` per slice. Rows ordered by mean rank across the window.
+**Bold** = Dec-2022 transition value for topics whose rank shifted ≥3 positions
+across the step (T139 also bolds the pre-step rank=21 marking out-of-Top-20).
 
 | topic | top words (8) | 22-06 | 22-07 | 22-08 | 22-09 | 22-10 | 22-11 | 22-12 | 23-01 | 23-02 | 23-03 | 23-04 | 23-05 | 23-06 | 23-07 | 23-08 |
 |---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -90,6 +92,8 @@ Jun/Jul/Aug → **0 / 3 confirmed**.
 
 Source: `/mnt/data/tmp/corpus-diagnostics/doc-length/summary_by_date.csv`.
 `n_docs` is exact count (post-dedup). `*_pNN` are `percentile_approx`, accuracy=10000.
+**Bold** = Oct/Nov 2022 highs and Dec-2022 step values; ↓ marks the Dec-2022
+step direction relative to Oct/Nov.
 
 | date | n_docs | char_mean | char_stddev | char_p05 | char_p25 | char_p50 | char_p75 | char_p95 | word_mean | word_p25 | word_p50 | word_p75 | word_p95 |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
@@ -142,7 +146,8 @@ Dec-2022.
 
 Source: `/mnt/data/tmp/corpus-diagnostics/en-density/summary_by_date.csv` (regex-fixed).
 Stopwords: `{the, and, for, with, you, this, that, from, have, not}`, word-bounded,
-case-insensitive.
+case-insensitive. **Bold** row = Dec-2022 step values; ↑ marks direction
+relative to Oct/Nov 2022.
 
 | date | en_density_mean | en_density_p50 | en_density_p95 | frac_above_05 | frac_above_10 |
 |---|---:|---:|---:|---:|---:|
@@ -208,16 +213,13 @@ that's independent of the Dec-2022 topic step; worth a follow-up.
 
 ## 9. Lineage / files
 
+Full file inventory (sources, diagnostic jobs, companion worklogs) in the
+narrative note's "Lineage / files used" section. The number tables above were
+generated from:
+
 | What | Where |
 |---|---|
-| Held-out K=200 topic proportions | `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet` |
-| K=200 topic words (200 × 100 terms) | `/mnt/data/tmp/lda-k200-converged/k200/topicWords_lda.txt` |
-| Source parquets | `/mnt/data/tmp/longeval-{train,test}-parquet/Documents/` (split=…/language=…/date=…) |
-| Diagnostic job (fused B1+B2+B3 + top-hashes) | `/mnt/data/tmp/corpus-diagnostics/run_diagnostics.py` |
-| B3 regex-fix job | `/mnt/data/tmp/corpus-diagnostics/run_b3_fix.py` |
+| K=200 held-out topic proportions | `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet` |
+| K=200 topic words | `/mnt/data/tmp/lda-k200-converged/k200/topicWords_lda.txt` |
 | B1/B2/B3 CSVs | `/mnt/data/tmp/corpus-diagnostics/{doc-length,dedup,en-density}/summary_by_date.csv` |
 | Top-20 boilerplate hashes per slice | `/mnt/data/tmp/corpus-diagnostics/dedup/top_hashes_by_date.parquet` |
-| Narrative + hypothesis ranking | [`20260528-lda-k200-rank-stability-seasonality-shift.md`](20260528-lda-k200-rank-stability-seasonality-shift.md) |
-| K=200 training + register pattern | [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) |
-| Cross-K saturation summary | [`20260528-lda-k-granularity-saturation.md`](20260528-lda-k-granularity-saturation.md) |
-| K=4 worklog (100% FR labelled) | [`../acmiyaguchi/20260519-lda-k4-worklog.md`](../acmiyaguchi/20260519-lda-k4-worklog.md) |

--- a/user/anthony/20260528-corpus-diagnostics-numbers.md
+++ b/user/anthony/20260528-corpus-diagnostics-numbers.md
@@ -1,0 +1,223 @@
+# Numbers reference — K=200 rank stability + seasonality + Dec-2022 corpus diagnostics
+
+Date: 2026-05-28
+Companion to [`20260528-lda-k200-rank-stability-seasonality-shift.md`](20260528-lda-k200-rank-stability-seasonality-shift.md) (narrative)
+and [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) (K=200 training).
+
+Single-file dump of every per-slice number mined this session: K=200 rank/θ
+matrices, seasonality probe θ traces, source-data B1/B2/B3 per slice, and
+top-3 boilerplate-hash counts per slice.
+
+---
+
+## 1. K=200 rank matrix — 21 topics ever in Top-20
+
+Source: `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet`,
+ranked by `mean_theta` per slice. Rows ordered by mean rank across the window.
+
+| topic | top words (8) | 22-06 | 22-07 | 22-08 | 22-09 | 22-10 | 22-11 | 22-12 | 23-01 | 23-02 | 23-03 | 23-04 | 23-05 | 23-06 | 23-07 | 23-08 |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| T47  | peut_être, quelqu_chos, peu, quand, bien_sûr, donc, quelqu, faut | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
+| T198 | like, one, get, time, would, post, make, know | 3 | 3 | 3 | 3 | 3 | 3 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 | 2 |
+| T48  | year_old, one, year, time, first, world, peopl, day | 4 | 4 | 4 | 5 | 4 | 4 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 |
+| T16  | histoir, livr, auteu, vie, home, mond, siecl, plu_tard | 2 | 2 | 2 | 2 | 2 | 2 | **5** | 5 | 5 | 5 | 5 | 5 | 5 | 5 | 5 |
+| T89  | stat, year, said, president, vice_president, government, work, ofic | 6 | 6 | 6 | 6 | 5 | 5 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 4 |
+| T111 | doit_être, peut_être, peuvent_être, doivent_être, consider_come, doit, cas, peuvent | 12 | 12 | 12 | 8 | 12 | 12 | 7 | 7 | 8 | 8 | 7 | 8 | 6 | 7 | 6 |
+| T59  | polit, contr, premi_ministr, gouvern, publ_champ, obligatoir_indiqu, president, parti | 7 | 7 | 7 | 7 | 8 | 8 | 12 | 12 | 11 | 10 | 11 | 11 | 10 | 11 | 11 |
+| T122 | chang_climat, lute_contr, develop_durabl, climat, develop, projet, mise_œuvr, econom | 5 | 5 | 5 | 4 | 6 | 6 | **13** | 13 | 13 | 13 | 14 | 14 | 12 | 13 | 12 |
+| T110 | travail, pris_charg, entrepris, profesion, social, mise_plac, sala, travaileu | 11 | 11 | 11 | 12 | 11 | 11 | 10 | 9 | 9 | 9 | 9 | 9 | 9 | 9 | 10 |
+| T40  | may, side_efect, use, patient, cell, treatment, diseas, pric | 20 | 20 | 20 | 18 | 16 | 16 | **6** | 6 | 6 | 6 | 6 | 6 | 7 | 6 | 7 |
+| T175 | livraison_gratuit, couleu, produit, aci_inoxydabl, haut, tail, noir, acesoir | 13 | 13 | 13 | 13 | 13 | 13 | 9 | 10 | 12 | 12 | 10 | 10 | 11 | 10 | 9 |
+| T72  | jeu, premier_foi, plu_tard, joueu, equip, coup, mesag, saison | 10 | 10 | 10 | 11 | 10 | 10 | 14 | 14 | 14 | 14 | 13 | 13 | 13 | 14 | 13 |
+| T139 | pric, home, room, sale, city, area, park, view | **21** | 21 | 21 | 21 | 20 | 20 | **8** | 8 | 7 | 7 | 8 | 7 | 8 | 8 | 8 |
+| T121 | week_end, musiqu, rue, even, artist, spectacl, ateli, anim | 8 | 8 | 8 | 10 | 7 | 7 | **18** | 18 | 18 | 18 | 18 | 18 | 18 | 18 | 18 |
+| T44  | projet, entrepris, trans_ecolog, elisabeth_born, trans_energet, transport, develop, econom | 9 | 9 | 9 | 9 | 9 | 9 | **19** | 19 | 19 | 19 | 19 | 19 | 19 | 19 | 19 |
+| T185 | email_adres, email, privacy_policy, websit, pleas, use, right_reserved, pleas_ent | 19 | 19 | 19 | 20 | 21 | 21 | 11 | 11 | 10 | 11 | 12 | 12 | 14 | 12 | 14 |
+| T94  | mot_pase, adres_mail, adres_email, mail, mot, pase_oubl, pase, email | 15 | 15 | 15 | 15 | 17 | 17 | 15 | 15 | 15 | 15 | 15 | 15 | 15 | 15 | 15 |
+| T14  | produit, comand, livraison, client, delai_livraison, cadeau, achat, paie_securis | 17 | 17 | 17 | 14 | 14 | 14 | 16 | 16 | 16 | 17 | 16 | 16 | 16 | 16 | 16 |
+| T98  | 1er_janvi, revenu, impot, impot_revenu, financi, tau, fiscal, entrepris | 16 | 16 | 16 | 17 | 15 | 15 | 17 | 17 | 17 | 16 | 17 | 17 | 17 | 17 | 17 |
+| T90  | site_web, cok, utilis, reseau_social, web, peuvent_être, utilison_cok, navig | 18 | 18 | 18 | 19 | 19 | 19 | 20 | 20 | 20 | 20 | 20 | 20 | 20 | 20 | 20 |
+| T42  | jean, jean_pier, pier, mar, jean_claud, michel, jean_francoi, jacqu | 14 | 14 | 14 | 16 | 18 | 18 | **28** | 28 | 28 | 28 | 30 | 28 | 29 | 28 | 29 |
+
+Top-20 *core* (Top-20 at every slice) = 18 / 20. Top-20 *union* = 21 / 200.
+Only swap: **T42 out → T139 in** at Dec-2022.
+
+## 2. K=200 θ matrix (×10⁻⁴) — same 21 topics
+
+| topic | 22-06 | 22-07 | 22-08 | 22-09 | 22-10 | 22-11 | 22-12 | 23-01 | 23-02 | 23-03 | 23-04 | 23-05 | 23-06 | 23-07 | 23-08 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| T47  | 543.5 | 543.3 | 543.9 | 564.3 | 503.1 | 502.5 | 404.6 | 405.2 | 403.2 | 408.1 | 408.5 | 408.5 | 416.0 | 409.3 | 415.9 |
+| T198 | 329.7 | 329.5 | 328.7 | 290.3 | 307.6 | 305.3 | 382.0 | 381.7 | 386.1 | 382.9 | 375.5 | 378.2 | 361.3 | 377.0 | 360.7 |
+| T48  | 310.4 | 310.4 | 309.7 | 267.4 | 301.9 | 299.8 | 346.2 | 346.0 | 349.9 | 352.3 | 345.9 | 348.6 | 334.8 | 347.4 | 334.9 |
+| T16  | 346.1 | 344.7 | 345.6 | 342.1 | 324.0 | 324.2 | 244.3 | 245.3 | 243.3 | 248.6 | 250.9 | 250.3 | 253.9 | 250.0 | 253.6 |
+| T89  | 274.4 | 274.1 | 273.3 | 234.5 | 276.5 | 274.5 | 322.3 | 322.0 | 326.1 | 329.6 | 323.7 | 325.6 | 313.6 | 324.7 | 313.1 |
+| T111 | 167.1 | 166.9 | 166.8 | 186.8 | 175.0 | 174.9 | 187.0 | 187.3 | 186.3 | 183.4 | 184.9 | 184.5 | 190.3 | 185.0 | 189.5 |
+| T59  | 218.6 | 218.4 | 217.6 | 195.4 | 191.2 | 191.8 | 166.3 | 166.9 | 168.8 | 174.2 | 172.6 | 172.6 | 176.1 | 173.3 | 175.2 |
+| T122 | 280.7 | 279.5 | 281.2 | 273.7 | 270.2 | 269.9 | 162.8 | 163.3 | 162.8 | 165.1 | 164.8 | 164.4 | 170.0 | 165.4 | 169.0 |
+| T110 | 171.3 | 170.4 | 170.2 | 173.6 | 178.3 | 178.7 | 173.1 | 174.7 | 174.4 | 176.0 | 175.9 | 175.6 | 176.2 | 175.6 | 175.6 |
+| T40  | 127.1 | 127.3 | 126.9 | 135.1 | 142.1 | 140.9 | 188.8 | 188.7 | 191.1 | 192.0 | 188.6 | 190.1 | 181.5 | 189.7 | 182.8 |
+| T175 | 165.4 | 165.4 | 166.1 | 170.6 | 170.0 | 171.3 | 173.8 | 173.8 | 168.0 | 170.0 | 175.9 | 173.9 | 174.6 | 174.1 | 177.4 |
+| T72  | 177.3 | 176.7 | 175.3 | 181.6 | 179.5 | 179.8 | 162.1 | 161.6 | 162.6 | 165.1 | 164.9 | 165.2 | 164.8 | 165.1 | 165.0 |
+| T139 | 121.9 | 121.8 | 121.5 | 113.7 | 118.7 | 117.9 | 185.3 | 185.2 | 187.7 | 186.8 | 183.7 | 184.7 | 176.7 | 184.0 | 177.6 |
+| T121 | 198.1 | 197.5 | 198.2 | 182.7 | 192.1 | 193.1 | 150.8 | 150.7 | 151.2 | 153.6 | 155.1 | 154.4 | 155.0 | 154.6 | 155.5 |
+| T44  | 192.5 | 193.4 | 194.2 | 183.4 | 190.5 | 190.4 | 144.8 | 145.8 | 146.2 | 148.8 | 149.2 | 148.3 | 150.4 | 148.5 | 150.0 |
+| T185 | 131.6 | 131.5 | 131.3 | 115.6 | 118.5 | 117.9 | 169.2 | 169.0 | 171.1 | 171.4 | 168.9 | 169.8 | 164.3 | 169.2 | 164.1 |
+| T94  | 151.7 | 151.7 | 150.7 | 151.5 | 139.1 | 139.5 | 161.3 | 161.4 | 160.5 | 159.4 | 161.0 | 160.7 | 163.4 | 160.8 | 163.1 |
+| T14  | 140.6 | 140.5 | 140.6 | 151.6 | 162.8 | 163.8 | 159.7 | 157.9 | 154.1 | 155.2 | 160.0 | 158.4 | 158.1 | 158.5 | 160.0 |
+| T98  | 141.3 | 140.8 | 141.2 | 141.2 | 150.0 | 150.2 | 151.1 | 152.5 | 152.5 | 156.9 | 158.0 | 157.5 | 157.2 | 156.5 | 158.1 |
+| T90  | 134.3 | 134.2 | 134.0 | 119.8 | 123.0 | 123.1 | 139.7 | 140.4 | 139.5 | 141.9 | 143.8 | 143.0 | 143.0 | 142.8 | 143.1 |
+| T42  | 154.2 | 154.0 | 153.3 | 147.3 | 127.0 | 127.3 |  96.6 |  96.7 |  97.4 |  97.1 |  96.7 |  96.7 |  97.0 |  96.8 |  96.6 |
+
+## 3. Seasonality probe θ traces (×10⁻⁴)
+
+Topics chosen for max-seasonal vocabulary. See narrative note for the YoY co-spike
+algorithm; here just the raw monthly θ.
+
+| topic | top words | 22-06 | 22-07 | 22-08 | 22-09 | 22-10 | 22-11 | 22-12 | 23-01 | 23-02 | 23-03 | 23-04 | 23-05 | 23-06 | 23-07 | 23-08 |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| T68  | fête_mère, maman                       | 25.73 | 25.77 | 25.66 | 25.54 | 20.73 | 20.69 |  5.34 |  5.34 |  5.29 |  5.20 |  5.24 |  5.34 |  5.44 |  5.25 |  5.29 |
+| T78  | vote, election_legislatif              | 56.43 | 56.34 | 56.13 | 17.66 | 13.88 | 13.81 | 13.45 | 13.59 | 13.71 | 13.42 | 13.40 | 13.52 | 13.15 | 13.42 | 13.30 |
+| T82  | père_noël, xvie_siecl                  | 27.74 | 27.71 | 27.71 | 33.34 | 25.72 | 25.64 | 13.99 | 13.99 | 13.99 | 13.31 | 13.30 | 13.38 | 13.98 | 13.40 | 13.66 |
+| T101 | fleu, bouquet_fleu, saint_valentin     | 42.75 | 42.73 | 42.56 | 42.81 | 56.72 | 57.16 | 18.95 | 19.01 | 18.95 | 18.97 | 19.40 | 19.38 | 19.38 | 19.25 | 19.53 |
+| T155 | academy_award, film_wining             |  9.01 |  9.01 |  8.97 | 11.61 | 27.25 | 27.07 | 27.76 | 27.90 | 28.31 | 28.54 | 28.09 | 27.98 | 28.04 | 27.90 | 28.12 |
+| T190 | election_legislatif (variant)          | 86.08 | 85.87 | 85.41 | 28.67 | 30.59 | 30.52 | 33.39 | 33.76 | 34.35 | 35.54 | 35.18 | 35.30 | 34.81 | 35.41 | 34.90 |
+
+Funnel: naive pre/post detrend → 70 candidates (35 peaking Sep-2022); rolling-median
+detrend (window=3) → 18 candidates (still Sep-2022-clustered); YoY co-spike on
+Jun/Jul/Aug → **0 / 3 confirmed**.
+
+## 4. B1 — document length distribution per slice
+
+Source: `/mnt/data/tmp/corpus-diagnostics/doc-length/summary_by_date.csv`.
+`n_docs` is exact count (post-dedup). `*_pNN` are `percentile_approx`, accuracy=10000.
+
+| date | n_docs | char_mean | char_stddev | char_p05 | char_p25 | char_p50 | char_p75 | char_p95 | word_mean | word_p25 | word_p50 | word_p75 | word_p95 |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 2022-06 | 1,590,024 | 5229 | 3437 | 545 | 2158 | 4596 | 9037 | 10080 | 827 | 343 | 728 | 1347 | 1692 |
+| 2022-07 | 1,591,964 | 5225 | 3436 | 545 | 2155 | 4594 | 9029 | 10080 | 826 | 342 | 728 | 1345 | 1692 |
+| 2022-08 | 1,600,735 | 5235 | 3443 | 544 | 2152 | 4606 | 9073 | 10080 | 828 | 342 | 730 | 1352 | 1692 |
+| 2022-09 | 1,080,369 | 5300 | 3455 | 560 | 2185 | 4676 | 9269 | 10082 | 843 | 345 | 743 | 1401 | 1705 |
+| 2022-10 | 2,137,543 | **5421** | 3411 | 626 | 2380 | 4840 | 9501 | 10081 | 860 | 379 | 760 | 1419 | 1704 |
+| 2022-11 | 2,153,685 | **5418** | 3410 | 626 | 2377 | 4837 | 9484 | 10081 | 859 | 379 | 760 | 1417 | 1703 |
+| **2022-12** | 2,046,071 | **5054** ↓ | 3413 | **489** | **2046** | **4364** ↓ | **8538** | 10080 | **801** ↓ | **323** | **682** ↓ | 1323 | 1688 |
+| 2023-01 | 2,048,378 | 5056 | 3413 | 489 | 2048 | 4372 | 8539 | 10080 | 802 | 323 | 683 | 1323 | 1688 |
+| 2023-02 | 2,014,702 | 5058 | 3418 | 479 | 2040 | 4382 | 8554 | 10080 | 802 | 322 | 685 | 1323 | 1688 |
+| 2023-03 | 2,008,495 | 5060 | 3418 | 480 | 2042 | 4385 | 8563 | 10080 | 802 | 322 | 685 | 1324 | 1688 |
+| 2023-04 | 1,993,335 | 5049 | 3418 | 477 | 2031 | 4365 | 8539 | 10080 | 800 | 321 | 682 | 1321 | 1687 |
+| 2023-05 | 2,033,525 | 5050 | 3419 | 476 | 2031 | 4368 | 8544 | 10080 | 800 | 320 | 682 | 1321 | 1688 |
+| 2023-06 | 1,444,601 | 5087 | 3420 | 486 | 2060 | 4427 | 8626 | 10080 | 806 | 325 | 692 | 1332 | 1687 |
+| 2023-07 | 1,940,277 | 5057 | 3419 | 479 | 2037 | 4379 | 8559 | 10080 | 801 | 321 | 684 | 1323 | 1688 |
+| 2023-08 | 1,489,204 | 5080 | 3421 | 486 | 2052 | 4417 | 8615 | 10080 | 805 | 324 | 690 | 1331 | 1687 |
+
+p95 char is essentially flat at ~10080 across the whole window (a likely soft cap at
+~10K chars). The Dec-2022 step is in lower percentiles only.
+
+## 5. B2 — content-hash uniqueness per slice
+
+Source: `/mnt/data/tmp/corpus-diagnostics/dedup/summary_by_date.csv`.
+`n_unique_contents` from `approx_count_distinct(sha256(contents), rsd=0.01)`.
+
+| date | n_docs | n_unique_contents | unique_frac |
+|---|---:|---:|---:|
+| 2022-06 | 1,590,024 | 1,421,939 | 0.894 |
+| 2022-07 | 1,591,964 | 1,424,084 | 0.895 |
+| 2022-08 | 1,600,735 | 1,440,703 | 0.900 |
+| 2022-09 | 1,080,369 |   985,906 | 0.913 |
+| 2022-10 | 2,137,543 | 1,865,743 | 0.873 |
+| 2022-11 | 2,153,685 | 1,879,165 | 0.873 |
+| 2022-12 | 2,046,071 | 1,815,365 | 0.887 |
+| 2023-01 | 2,048,378 | 1,822,010 | 0.889 |
+| 2023-02 | 2,014,702 | 1,778,464 | 0.883 |
+| 2023-03 | 2,008,495 | 1,771,891 | 0.882 |
+| 2023-04 | 1,993,335 | 1,750,625 | 0.878 |
+| 2023-05 | 2,033,525 | 1,804,830 | 0.888 |
+| 2023-06 | 1,444,601 | 1,290,387 | 0.893 |
+| 2023-07 | 1,940,277 | 1,715,607 | 0.884 |
+| 2023-08 | 1,489,204 | 1,315,611 | 0.883 |
+
+unique_frac stays in 0.87–0.91 across the whole window. No discontinuity at
+Dec-2022.
+
+## 6. B3 — EN-stopword density per slice
+
+Source: `/mnt/data/tmp/corpus-diagnostics/en-density/summary_by_date.csv` (regex-fixed).
+Stopwords: `{the, and, for, with, you, this, that, from, have, not}`, word-bounded,
+case-insensitive.
+
+| date | en_density_mean | en_density_p50 | en_density_p95 | frac_above_05 | frac_above_10 |
+|---|---:|---:|---:|---:|---:|
+| 2022-06 | 0.0250 | 0.0 | 0.1359 | 0.2017 | 0.1388 |
+| 2022-07 | 0.0251 | 0.0 | 0.1360 | 0.2027 | 0.1396 |
+| 2022-08 | 0.0250 | 0.0 | 0.1360 | 0.2022 | 0.1393 |
+| 2022-09 | 0.0236 | 0.0 | 0.1341 | 0.1920 | 0.1304 |
+| 2022-10 | 0.0245 | 0.0 | 0.1354 | 0.1990 | 0.1345 |
+| 2022-11 | 0.0244 | 0.0 | 0.1352 | 0.1975 | 0.1335 |
+| **2022-12** | **0.0295** ↑ | 0.0 | **0.1400** ↑ | **0.2410** ↑ | **0.1607** ↑ |
+| 2023-01 | 0.0294 | 0.0 | 0.1400 | 0.2407 | 0.1604 |
+| 2023-02 | 0.0298 | 0.0 | 0.1402 | 0.2436 | 0.1624 |
+| 2023-03 | 0.0298 | 0.0 | 0.1403 | 0.2440 | 0.1627 |
+| 2023-04 | 0.0293 | 0.0 | 0.1399 | 0.2397 | 0.1598 |
+| 2023-05 | 0.0295 | 0.0 | 0.1400 | 0.2413 | 0.1610 |
+| 2023-06 | 0.0284 | 0.0 | 0.1392 | 0.2322 | 0.1547 |
+| 2023-07 | 0.0294 | 0.0 | 0.1399 | 0.2406 | 0.1604 |
+| 2023-08 | 0.0284 | 0.0 | 0.1392 | 0.2322 | 0.1546 |
+
+Median is 0.0 throughout — most FR docs contain no EN stopwords at all. The signal
+is entirely in the right tail. `frac_above_05` step: 0.198 → 0.241 (+22 % rel).
+
+## 7. Top-3 boilerplate hashes per slice
+
+Source: `/mnt/data/tmp/corpus-diagnostics/dedup/top_hashes_by_date.parquet`.
+`n` is per-slice occurrence count of an exact-duplicate document text. Threshold
+filter `n ≥ 50` was applied before ranking.
+
+| date | r1 hash | r1 n | r2 hash | r2 n | r3 hash | r3 n |
+|---|---|---:|---|---:|---|---:|
+| 2022-06 | b6d12ab… | **13,288** | eccfc75… | 1,508 | d892a81… | 1,058 |
+| 2022-07 | b6d12ab… | **13,277** | eccfc75… | 1,507 | d892a81… | 1,058 |
+| 2022-08 | b6d12ab… | **13,273** | eccfc75… | 1,498 | d892a81… | 1,053 |
+| 2022-09 | eccfc75… | 1,496 | 9518830… | 759 | 0cdc276… | 535 |
+| 2022-10 | 78a2652… | 5,032 | 6d9e78b… | 3,116 | 5e21fba… | 2,152 |
+| 2022-11 | 78a2652… | 5,030 | 6d9e78b… | 3,115 | dc3e3d6… | 2,504 |
+| 2022-12 | 78a2652… | 5,045 | dc3e3d6… | 3,442 | 6d9e78b… | 3,084 |
+| 2023-01 | 78a2652… | 5,021 | 6d9e78b… | 3,082 | dc3e3d6… | 2,536 |
+| 2023-02 | 78a2652… | 4,937 | 0d5767c… | 3,425 | 6d9e78b… | 3,085 |
+| 2023-03 | 78a2652… | 4,909 | 0d5767c… | 3,429 | 6d9e78b… | 3,082 |
+| 2023-04 | 78a2652… | 4,764 | 0d5767c… | 3,344 | 6d9e78b… | 3,103 |
+| 2023-05 | 78a2652… | 4,888 | 0d5767c… | 3,403 | 6d9e78b… | 3,093 |
+| 2023-06 | 78a2652… | 3,393 | 6d9e78b… | 2,688 | 0d5767c… | 2,362 |
+| 2023-07 | 78a2652… | 4,637 | 0d5767c… | 3,168 | 6d9e78b… | 2,995 |
+| 2023-08 | 78a2652… | 3,427 | 6d9e78b… | 2,668 | 0d5767c… | 2,402 |
+
+**Discovery surfaced by the table** (not yet folded into narrative): the dominant
+boilerplate hash *changes identity* at Sep→Oct 2022, not at Dec 2022.
+`b6d12ab…` (13K copies/slice in Jun–Aug 2022) vanishes from the top-3 entirely
+after Aug, replaced by `78a2652…` (5K copies) from Oct 2022 onward. The
+intermediate Sep 2022 slice (smaller N at 1.08M) has neither hash dominant.
+B2 unique_frac doesn't change much across this boundary — total boilerplate volume
+is similar, but the *fingerprint* shifted. Could be a separate Sep/Oct boundary
+that's independent of the Dec-2022 topic step; worth a follow-up.
+
+## 8. Aggregate corpus size
+
+| collection | n_docs | unique_frac | char_mean |
+|---|---:|---:|---:|
+| train (9 slices 2022-06 → 2023-02) | 16,263,471 | ~0.88 | ~5215 |
+| test (6 slices 2023-03 → 2023-08) | 10,909,437 | ~0.88 | ~5063 |
+| **total** | **27,172,908** | | |
+
+## 9. Lineage / files
+
+| What | Where |
+|---|---|
+| Held-out K=200 topic proportions | `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet` |
+| K=200 topic words (200 × 100 terms) | `/mnt/data/tmp/lda-k200-converged/k200/topicWords_lda.txt` |
+| Source parquets | `/mnt/data/tmp/longeval-{train,test}-parquet/Documents/` (split=…/language=…/date=…) |
+| Diagnostic job (fused B1+B2+B3 + top-hashes) | `/mnt/data/tmp/corpus-diagnostics/run_diagnostics.py` |
+| B3 regex-fix job | `/mnt/data/tmp/corpus-diagnostics/run_b3_fix.py` |
+| B1/B2/B3 CSVs | `/mnt/data/tmp/corpus-diagnostics/{doc-length,dedup,en-density}/summary_by_date.csv` |
+| Top-20 boilerplate hashes per slice | `/mnt/data/tmp/corpus-diagnostics/dedup/top_hashes_by_date.parquet` |
+| Narrative + hypothesis ranking | [`20260528-lda-k200-rank-stability-seasonality-shift.md`](20260528-lda-k200-rank-stability-seasonality-shift.md) |
+| K=200 training + register pattern | [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) |
+| Cross-K saturation summary | [`20260528-lda-k-granularity-saturation.md`](20260528-lda-k-granularity-saturation.md) |
+| K=4 worklog (100% FR labelled) | [`../acmiyaguchi/20260519-lda-k4-worklog.md`](../acmiyaguchi/20260519-lda-k4-worklog.md) |

--- a/user/anthony/20260528-lda-k-granularity-saturation.md
+++ b/user/anthony/20260528-lda-k-granularity-saturation.md
@@ -1,0 +1,170 @@
+# LDA K-granularity saturation: K=4 → K=20 → K=200
+
+Date: 2026-05-28
+
+## TL;DR
+
+We now have three converged LDA models on the same pooled 9-slice corpus
+(16,263,471 docs, identical vocab + phrases via hardlinked preprocess) and
+their held-out 15-slice inferences against the 6 test slices: **K=4** (CLEF
+paper headline), **K=20** (granular companion), **K=200** (granularity anchor,
+trained 2026-05-27 → 28).
+
+The Dec-2022 document regime change has a **fixed structural magnitude that
+K=20 already captures, and K=200 does not add to**. Held-out pre→post Dec-2022
+L1 mass shift saturates around K=20:
+
+| K  | held-out L1 mass shift (Σ\|Δ\|) | max single-topic Δ | substantive interpretation |
+|---:|---:|---:|---|
+|  4 | 0.106  | T3 −0.054 | macro register swap (T0 ↑ / T3 ↓) |
+| 20 | 0.2011 | T16 −0.048 | fine register swap (T16 substantive FR ↓ / T8 generic EN ↑) |
+| **200** | **0.2115** | **T47 −0.013** | **same swap diffused over many fine registers** |
+
+K=20 = the right granularity for the writeup. K=200 = corroboration anchor,
+not additive evidence. The K=200 register pattern reads the same as K=20 at
+finer resolution: **substitution of substantive French prose with
+English-language web content + commerce/booking boilerplate** — a
+crawl/extraction regime change, not a language-mix shift (the corpus is
+100 % French-labelled at every one of the 15 slices, see `20260519-lda-k4-worklog.md`
+Finding #2).
+
+## What's new (today, 2026-05-28)
+
+1. **K=200 converged model trained** (~7 h LDA fit; pipeline end-to-end
+   ~10 h; coherence/Eval and held-out drift both validated).
+   Worklog: [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md).
+2. **K=200 held-out 15-slice drift ran clean** (2026-05-27 23:29 → 28 01:29,
+   2 h wall, no errors). Inference Stage 20 hit a swap-pressure cliff at
+   16/40 parts (driver RSS 60 GB, swap 12 → 24 GiB) but cleared on its own.
+3. **L1 mass shift saturation between K=20 and K=200 established** (0.201 →
+   0.211). The granularity question is now settled.
+4. **Figure 2 panel (a) extended to all 15 slices** in the paper repo using
+   the held-out K=4 inference values (commit pending). The held-out test
+   window holds flat as a plateau through 2023-08 — no decay, no reversion.
+
+## Why this matters for the paper
+
+We had three open questions in the topic-modeling section:
+
+- **Q1.** Does the Dec-2022 step survive into the test window, or does it
+  decay back? — **A:** flat plateau through 2023-08, at every K we measured.
+- **Q2.** Is the step a coarse artifact of the K=4 binning, or does it
+  reproduce at finer granularity? — **A:** reproduces at K=20 (8 sub-registers
+  move), reproduces at K=200 (top-15 movers ≈ 45 % of the same total mass
+  shift), saturates by K=20. Not a binning artifact.
+- **Q3.** Is the step a language-composition shift ("more English documents")
+  or a content shift inside French-labelled documents? — **A:**
+  language-composition is constant (100 % FR labelled at all 15 slices;
+  Finding #2 in `20260519-lda-k4-worklog.md`). It is a content shift:
+  substantive French prose registers lose mass; English-language content
+  registers + booking/cookie boilerplate gain mass. The crawler/extractor
+  started surfacing more EN content and stopped surfacing as much substantive
+  FR prose, within the same French-labelled crawl.
+
+The K=200 top-mover register table makes Q3 unambiguous. Down-movers (lose
+mass post-Dec-2022) are uniformly substantive French registers; up-movers are
+uniformly English-language web content + commerce boilerplate:
+
+| direction | register | top words |
+|---|---|---|
+| ↓ T47 (Δ −0.013) | FR generic narrative prose / fillers | peut_être, quelqu_chose, faut, alors, dit, vie, dire, beaucoup |
+| ↓ T122 (Δ −0.011) | climate / sustainable-development discourse | chang_climat, develop_durabl, nation_unie, environ, polit |
+| ↓ T16 (Δ −0.009) | FR history / literature | histoir, livr, auteu, siecl, guer, dieu, roman |
+| ↓ T44 (Δ −0.005) | FR politico-economic transitions | projet, trans_ecolog, elisabeth_born, trans_energet, econom |
+| ↓ T164 (Δ −0.004) | FR film / audiovisual credits | jean, production, catalogu_audiovisuel, francofol_rochel |
+| ↓ T121 (Δ −0.004) | FR cultural events / festivals | musiqu, artist, spectacl, festival, theatr, concert |
+| ↓ T42 (Δ −0.004) | FR given-name biographical listings | jean, pier, mar, michel, claud |
+| ↑ T139 (Δ +0.006) | EN hotel / travel commerce | pric, home, room, sale, hotel, travel, review |
+| ↑ T84 (Δ +0.006) | EN country / island geographic enumeration | island, virgin_island, cayman_island, falkland_island |
+| ↑ T198 (Δ +0.006) | EN forum / blog prose | like, one, get, would, post, know, think, want |
+| ↑ T89 (Δ +0.005) | EN business / government news | stat, year, president, government, busines, manag |
+| ↑ T40 (Δ +0.005) | EN medical / pharma | may, side_efect, patient, treatment, diseas, drug, canc |
+| ↑ T48 (Δ +0.005) | EN narrative / biographical | year_old, life, said, man, war, book |
+| ↑ T145 (Δ +0.005) | FR hotel-booking boilerplate | centr_vile, anul_gratuit, hotel, recomandon_reserv |
+| ↑ T185 (Δ +0.004) | EN web-form / cookie boilerplate | email_adres, privacy_policy, cok, personal_data, pasword |
+
+## Per-K table (training-side, 9-slice pooled corpus)
+
+| metric | K=4 | K=20 | K=200 |
+|---|---:|---:|---:|
+| mean NPMI | 0.3542 | **0.3723** | 0.2586 |
+| topic diversity | 1.0000 | 0.9500 | 0.8690 |
+| coherence × diversity | **0.3542** | 0.3536 | 0.2247 |
+| topics with NPMI > 0.5 | 1 | 5 | 25 |
+| topics with NPMI < 0 (junk band) | 0 | 0 | 17 (8.5 %) |
+| max per-topic NPMI (tightest specialist) | 0.629 | 0.949 | **0.986** |
+| train-side Σ\|Δ\| first→last slice | 0.113 | 0.209 | 0.251 |
+| held-out Σ\|Δ\| pre→post Dec-2022 | 0.106 | 0.201 | 0.212 |
+
+**Reads.**
+- K=4 wins diversity, K=20 wins NPMI, the combined coh×div ties (K=4 marginal
+  optimum on the K=2..10 sweep, paper headline).
+- Tightest single topic gets tighter as K grows — fine granularity finds
+  hyper-specific registers (Paris museums at K=200 topic 0, English country
+  names at T84, etc.) — but the mean drops because the same vocabulary mass
+  has to be spread thinner.
+- **Held-out drift saturates between K=20 and K=200** (0.201 → 0.212). Train
+  drift keeps growing (0.21 → 0.25) because K=200 spreads the step across
+  more topics each with a small fragment; the held-out total mass that moves
+  is fixed.
+
+## Lineage / where everything lives
+
+| What | Where |
+|---|---|
+| K=4 worklog (CLEF paper model) | [`user/acmiyaguchi/20260519-lda-k4-worklog.md`](../acmiyaguchi/20260519-lda-k4-worklog.md) |
+| K=4 × K=20 attribution crosstab | [`user/acmiyaguchi/20260519-lda-k4xk20-attribution.md`](../acmiyaguchi/20260519-lda-k4xk20-attribution.md) |
+| K-selection sweep (K=2..10) analysis | [`user/acmiyaguchi/20260518-lda-k-selection.md`](../acmiyaguchi/20260518-lda-k-selection.md) |
+| K=200 worklog (this work) | [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) |
+| K=2..20 dense sweep scan | [`20260527-lda-k2-20-sweep-scan.md`](20260527-lda-k2-20-sweep-scan.md) (PR #39, branch `issue-36-lda-k-sweep`) |
+| Topic register names (LLM) | [`20260525-lda-topic-register-names.md`](20260525-lda-topic-register-names.md) |
+| K=4 converged model + archive | `/mnt/data/tmp/lda-k4-converged/` · `/mnt/data/research/arc/longeval-lda-k4-converged-archive/` |
+| K=20 converged model + archive | `/mnt/data/tmp/lda-k20-converged/` · `/mnt/data/research/arc/longeval-lda-k20-converged-archive/` |
+| K=200 converged model | `/mnt/data/tmp/lda-k200-converged/` (archive PENDING) |
+| Held-out drift parquets (K=4/K=20/K=200) | `/mnt/data/tmp/lda-k{4,20,200}-converged/heldout/topic_{proportions,drift}_15slice.parquet` |
+
+## Operational notes (lessons for K ≥ 100)
+
+- **Hardlink preprocess** (`cp -al /mnt/data/tmp/lda-k4-converged/preprocess
+  /mnt/data/tmp/lda-kN-converged/preprocess`) — MinePhrases/BuildFeatures
+  short-circuit on inode-identical `_config.json` / `_phrases_config.json`,
+  saving the per-K vocab build entirely. Pattern from
+  `project_incremental_k_sweep`.
+- **Spark driver memory ceiling ≈ 36–40 g** on this host (62 GiB total). K=4
+  and K=20 fit comfortably; K=200 *barely* fits at 40 g and spilled into swap
+  during held-out Stage 20 (driver RSS 60 GB > Xmx 40 g). Cleared on its own
+  this time. For the next K ≥ 100 run, prefer `--driver-memory 32g` or drop
+  `local[8] → local[4]` to halve Python-side parallelism. The historic
+  kernel-OOM-kill mode at 50 g over-commit is a hard ceiling not to cross.
+- **EvaluateLDAModel Python worker** crashed at K=200 attempt 1 (no Python
+  traceback because `spark.python.worker.faulthandler.enabled` was off), then
+  succeeded on Luigi auto-retry (same task hash, no config change). Marginal
+  memory pressure in `coherence.py`'s `_restrict(...).cache()`, not a
+  fundamental scaling break. Prophylactic config for next run:
+  ```
+  --conf spark.python.worker.faulthandler.enabled=true
+  --conf spark.executor.pyspark.memory=2g
+  --conf spark.master='local[4]'
+  --conf spark.sql.shuffle.partitions=400
+  ```
+- **SPARK_LOCAL_IP=127.0.0.1** still mandatory (wifi-drop kill mode).
+- **`/mnt/data/tmp` is durable nvme**, not tmpfs — survives reboot. Archive
+  guards against scratch housekeeping, not power loss.
+
+## Open
+
+1. **Archive K=200** to `longeval-lda-k200-converged-archive` matching the
+   K=4/K=20 pattern (MANIFEST.md, SHA256SUMS, ~50 MB), then GCS push to
+   `gs://dsgt-longeval-2025/` once both K=4 and K=20 archives are also
+   pushed (still pending explicit go-ahead).
+2. **Commit the paper repo edits** for the held-out 15-slice figure
+   extension (Figure 2 panel (a) and §4 text in
+   `../longeval-2025-best-of-labs`).
+3. **K4×K200 / K20×K200 attribution crosstabs** — *defer*. K=20 already
+   saturates the held-out mass shift; only worth doing if a reviewer asks
+   for per-document re-routing across the Dec-2022 boundary at K=200
+   resolution.
+4. **Held-out K=2..20 dense drift** — the issue #36 PR #39 sweep results
+   will populate this once it finishes. Will give a smooth granularity
+   curve for the saturation claim (rather than the three-point K=4/20/200
+   step we have now).

--- a/user/anthony/20260528-lda-k200-rank-stability-seasonality-shift.md
+++ b/user/anthony/20260528-lda-k200-rank-stability-seasonality-shift.md
@@ -75,8 +75,8 @@ peripheral, not part of the head-of-leaderboard story.
 
 ## Monthly seasonality probe — negative result
 
-Question: do any K=200 topics show calendar-month spikes (Saint-Valentin Feb,
-Fête des Mères May, Oscars Mar, Noël Dec, etc.)?
+Do any K=200 topics show calendar-month spikes (Saint-Valentin Feb, Fête des
+Mères May, Oscars Mar, Noël Dec)?
 
 ### The algorithmic recipe (reusable)
 
@@ -235,9 +235,8 @@ the B3 redo described below).
 | B3 frac_above_05 | 0.198 | 0.241 | **+22 %** |
 | B3 frac_above_10 | 0.133 | 0.160 | **+20 %** |
 
-The pre-step row deliberately uses Oct/Nov 2022 — they bracket the step in time and
-are the slices with the closest sample sizes (~2.15 M docs) to the post-step
-slices (~2.0 M docs), so the comparison is not confounded by N.
+Pre-step row uses Oct/Nov 2022: closest sample sizes (~2.15 M docs) to the
+post-step slices (~2.0 M docs), so the comparison isn't confounded by N.
 
 ### Verdict
 

--- a/user/anthony/20260528-lda-k200-rank-stability-seasonality-shift.md
+++ b/user/anthony/20260528-lda-k200-rank-stability-seasonality-shift.md
@@ -1,0 +1,290 @@
+# K=200 — rank stability, seasonality null, why the Dec-2022 step
+
+Date: 2026-05-28
+
+## TL;DR
+
+- **Top-20 is a near-closed set at K=200.** 18 of 20 topics sit in the Top-20 at
+  every one of the 15 slices; only 21 distinct topics ever appear in Top-20 at any
+  slice. **Exactly one swap** across the whole window (T42 FR given-names out,
+  T139 EN hotel/travel commerce in). The Dec-2022 step is rank-reshuffling
+  **inside** that closed set, not promotion from below.
+- **No monthly seasonality is detectable in this window.** Detrend (3-month
+  rolling median) → residual → year-over-year co-spike test returns 0/3 confirmed
+  candidates. Even maximally seasonal-vocabulary topics (T101 saint-valentin,
+  T68 fête-mère, T155 academy_award, T82 père_noël) show flat-plateau θ inside
+  each regime, no calendar peaks. With 14 monthly slices and a dominant Dec-2022
+  step, monthly seasonality lives below the noise floor.
+- **The Dec-2022 step is *inside* the training pool, not at the train/test
+  boundary** (train = 2022-06..2023-02, test = 2023-03..2023-08). That rules out
+  "dataset construction at the split boundary" as the cause. Leading hypotheses
+  are now (A) Qwant crawler/extractor update, (B) Qwant ranking/index change,
+  (C) intra-batch LongEval release switchover.
+
+See [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) for the K=200
+training run + register-pattern table; see
+[`20260528-lda-k-granularity-saturation.md`](20260528-lda-k-granularity-saturation.md)
+for the K=4 / K=20 / K=200 saturation framing; see
+[`20260528-corpus-diagnostics-numbers.md`](20260528-corpus-diagnostics-numbers.md)
+for the consolidated per-slice number tables (rank/θ matrices, B1/B2/B3 full,
+top-hash counts).
+
+## Top-20 / Top-50 rank stability at K=200
+
+Computed from the held-out 15-slice inference at
+`/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet`,
+ranking topics by mean θ within each slice.
+
+| metric | value |
+|---|---|
+| Top-20 *core* (in Top-20 at every one of 15 slices) | **18 / 20** |
+| Top-20 *union* (in Top-20 at any one slice) | **21 / 200** |
+| Top-50 *core* | 42 / 50 |
+| Top-50 *union* | 62 / 200 |
+| Topic at rank 1 in every slice | T47 (FR generic prose: `peut_être, quelqu_chos, faut, alor`) |
+| T47 θ drift through the window | 0.0544 → **0.0405** at Dec-2022 → 0.0416 plateau |
+
+**Top-5 trajectory** (the visible step is internal):
+
+```
+2022-06 to 2022-08:  T47 T16  T198 T48  T122
+2022-09:             T47 T16  T198 T122 T48
+2022-10 to 2022-11:  T47 T16  T198 T48  T89    ← T122 climate leaves Top-5
+2022-12 onward:      T47 T198 T48  T89  T16   ← T16 history demoted #2 → #5; locked for 9 mo
+```
+
+**The only Top-20 swap across 15 slices** (rank 21 vs 20 boundary):
+
+| direction | topic | rank 2022-06 → 2023-08 | top words |
+|---|---|---|---|
+| ↓ out | **T42** | 14 → 29 | `jean, jean_pier, mar, jean_claud, michel, jean_francoi` (FR given-name biographical) |
+| ↑ in | **T139** | 21 → 8 | `pric, home, room, sale, city, area, park, view, hous` (EN hotel/travel commerce) |
+
+**Within-Top-20 reshufflers** (no entry/exit, but big rank moves):
+
+- T122 climate / sustainable-dev: rank 5 → 12, θ 0.0281 → 0.0169
+- T44 FR energy-transition / Élisabeth Borne: rank 9 → 19, θ 0.0192 → 0.0150
+- T16 FR history/literature: rank 2 → 5, θ 0.0346 → 0.0254
+- T40 EN medical/pharma: rank 20 → 7, θ 0.0127 → 0.0183
+- T89 EN business/government news: rank 6 → 4, θ 0.0274 → 0.0313
+- T185 EN cookie/privacy boilerplate: rank 19 → 14, θ 0.0132 → 0.0164
+
+Outside Top-20, larger rank moves happen (T145 FR hotel-booking boilerplate
+183 → 34, T84 EN geographic enumeration 52 → 26) but on small absolute mass —
+peripheral, not part of the head-of-leaderboard story.
+
+## Monthly seasonality probe — negative result
+
+Question: do any K=200 topics show calendar-month spikes (Saint-Valentin Feb,
+Fête des Mères May, Oscars Mar, Noël Dec, etc.)?
+
+### The algorithmic recipe (reusable)
+
+```
+INPUT: heldout topic_proportions_15slice.parquet  (K × 15 monthly means)
+
+1. DETREND
+   For each topic: local_baseline = rolling_median(θ, window=3, center=True)
+                   residual       = θ − local_baseline
+   (rolling median is robust to single-month spikes AND absorbs the Dec-2022
+    step over 3 slices, unlike a simple pre/post-regime mean which over-detects
+    Sep–Nov 2022 as "seasonal".)
+
+2. SCORE candidates
+   For each topic:
+     peak_date     = argmax_d |residual(d)|
+     rel_excursion = |peak_residual| / max(θ)
+   Filter: typical θ > 0.001  AND  rel_excursion > 0.20
+
+3. DISCRIMINATE seasonal vs step-transition
+   YoY co-spike test: for each candidate peaking in {Jun, Jul, Aug},
+     require sign(resid_2022) == sign(resid_2023)
+            AND  |resid_2022|, |resid_2023| > 10% of typical θ
+   (kills Dec-2022-transition false positives because Sep–Nov peaks in 2022
+    have no 2023 counterpart.)
+
+4. SEMANTIC SANITY CHECK
+   For each surviving candidate, read topicWords_lda.txt top-15 terms.
+   Also flag the inverse — high-seasonal-vocab topics that FAIL the residual
+   test — that's the interesting null finding.
+
+5. (Requires N ≥ 24 months) STL decomposition
+   statsmodels.tsa.seasonal_decompose(θ_t, period=12, model='additive')
+   → clean trend/seasonal/residual split, no regime-step kludges.
+```
+
+### Result on K=200
+
+| step | output |
+|---|---|
+| Naive pre/post-regime detrend | 70 candidates, **35 peaking in Sep 2022 alone** — clearly misclassified step-transition |
+| Rolling-median detrend (window=3) | 18 candidates, all still clustered in Sep 2022 |
+| YoY co-spike test on Jun/Jul/Aug pairs | **0 hits** out of 3 testable months |
+
+### Label-driven probe (the clincher)
+
+Topics whose top words are maximally seasonal — checked against θ-by-month:
+
+| topic | vocabulary | expected peak | observed θ shape |
+|---|---|---|---|
+| T101 | `fleu, bouquet_fleu, saint_valentin` | Feb | step DOWN at Dec-2022 (0.0043 → 0.0019), **flat through Feb 2023** |
+| T68  | `fête_mère, maman` | late May | step DOWN (0.0026 → 0.0005), **flat through May 2023** |
+| T155 | `academy_award, film_wining` | Mar | step UP (0.0009 → 0.0028), then **0.0028 ± 0.0001 for 9 months** including Mar 2023 |
+| T82  | `père_noël, xvie_siecl` | Dec | step DOWN at the Dec we observe; no Dec bump either year |
+| T78/T190 | `vote, election_legislatif` | once-off | sharp drop after Sep 2022 — **French legislative election (Jun 2022), single event**, not annual |
+
+The vocabulary encodes seasonality because the *documents* have seasonal content.
+But the document **mix** at the corpus level is dominated by always-on web content,
+so the topic's θ is set by steady-state mass and barely flexes month to month.
+
+### Scope limit (the honest part)
+
+15 monthly slices spanning Jun 2022 → Aug 2023 with a one-month transition at
+Dec 2022:
+
+- **Only Jun/Jul/Aug have year-over-year pairs** → only 3 calendar months are
+  even testable for true annual periodicity
+- **Sep–Nov are 1 observation each** → cannot distinguish "September seasonal"
+  from "single-month event" from "step lead-in"
+- **Dec 2022 — Aug 2023** are all 1 observation each on the post-step plateau →
+  no within-regime seasonal signal observable
+
+Verdict: **K=200 resolves register/content shifts but not calendar cycles, given
+this window**. Recoverable signal would need ≥ 24 months and STL/X-13 decomposition.
+
+## Why would topic registers shift over time? — hypothesis ranking
+
+The shape that needs explaining:
+
+- **Discrete one-month step at Dec 2022**, flat plateau on both sides
+- **No `language` label change** — 100 % FR-labelled at every slice (see Finding #2
+  in [`../acmiyaguchi/20260519-lda-k4-worklog.md`](../acmiyaguchi/20260519-lda-k4-worklog.md))
+- **Doc and query sides decoupled** — document θ steps at Dec-2022; query θ shifts
+  at Sep-2022 along different topics (Figure 2 of the paper draft)
+- **Down-movers are substantive FR prose** (literature, history, climate, politics,
+  cinema, biographical)
+- **Up-movers are EN web content + commerce/legal boilerplate** (hotel booking,
+  cookie banners, privacy policies)
+
+Ranked mechanisms:
+
+1. **Qwant crawler/extractor update (leading)** — a new HTML extractor deployed
+   around Dec 2022 that retains chrome (booking forms, GDPR banners, footer
+   privacy text) where the previous version stripped it. The 10× jump in T145
+   (`centr_vile, anul_gratuit, recomandon_reserv`) from 0.0008 → 0.0081 is exactly
+   an extractor-tell. Single-month discreteness fits a deploy event.
+
+2. **Qwant ranking / index change (close second)** — Qwant publicly restructured
+   in late 2022 (leadership exit, Microsoft renegotiation). If the ranker started
+   surfacing more EN/Bing-syndicated results for the same FR queries, doc mix
+   would shift even with constant queries. **Argues against:** would usually be
+   gradual across multiple deploys, not a one-month step.
+
+3. **LongEval 2024 → 2025 re-collection pipeline difference** — confirmed by the
+   2024 Readme PDFs: LongEval 2024 covered **exactly 3 of our 15 slices**
+   (Jan 2023 train: 2,049,729 docs; Jun + Aug 2023 test: 4,321,642 docs total —
+   matches `id_urls_2023_{01,06,08}.txt` line counts to within 1). The other 12
+   slices in our 2025 corpus (incl. Jun–Dec 2022) were re-collected by LongEval
+   ~12–18 months later for the 2025 release. If the 2025 re-collection used a
+   different click-model snapshot, query log slice, or HTML extractor than the
+   original 2024 collection, that could plant a step somewhere in the 12 new
+   slices. **Does not directly explain Dec-2022 specifically** — would expect
+   the step at the 2024/2025 batch boundary, which is *not* Dec-2022 (Jan 2023
+   was the 2024 train month). But could explain why the post-step plateau is so
+   stable across the 9 newer slices.
+
+4. ~~User-query mix shift~~ — **rejected**. Query θ shifts at Sep-2022 (3 months
+   earlier) along different topics. If users drove document drift, the two sides
+   would move in sync.
+
+5. ~~Real-world content drift~~ — **rejected**. Genuine content drift is gradual
+   and partial. A one-month step held flat for 9 months is not what content drift
+   looks like.
+
+6. ~~Dataset construction at train/test boundary~~ — **rejected by exploration
+   today**. The boundary is Feb→Mar 2023, not Dec-2022. The step is inside the
+   training pool.
+
+## Diagnostics that would discriminate — results
+
+Three source-data probes were designed alongside this note. Each is a single
+Spark scan over the existing partitioned parquets at
+`/mnt/data/tmp/longeval-{train,test}-parquet/`. All outputs to
+`/mnt/data/tmp/corpus-diagnostics/<probe>/summary_by_date.csv`. Both runs used the
+fused-groupBy pattern described in `corpus-diagnostics/run_diagnostics.py` (single
+persist of a thin projection — `contents` dropped before cache so the budget is
+~1.4 GB rather than 60–80 GB; total wall ~11 min for B1+B2+B3 fused, +12 min for
+the B3 redo described below).
+
+| probe | what it measures | expected if (A) extractor | expected if (B) ranking | expected if (C) batch switch |
+|---|---|---|---|---|
+| **B1** doc-length distribution per slice (mean/median/p5/p25/p75/p95) | shape change at Dec-2022 | step + new short-doc mode | weak | possible |
+| **B2** within-slice content-hash uniqueness (`approx_count_distinct(sha256)/count`) | boilerplate retention rate | unique fraction drops sharply | no | possible |
+| **B3** EN-stopword density per doc (`the, and, for, with, you, this, …`) | EN-content infiltration in FR-labelled docs | weak (most chrome is FR-language) | step up | possible |
+
+### Observed (Oct/Nov 2022 vs Dec-2022 plateau)
+
+| signal | pre-step (Oct/Nov 2022) | post-step (Dec-2022 onward) | step polarity |
+|---|---|---|---|
+| B1 char_mean | 5418 | 5054 | **−7 %** |
+| B1 char_p50 | 4838 | 4364 | **−10 %** |
+| B1 word_p50 | 760 | 685 | **−10 %** |
+| B1 char_p95 | 10080 | 10080 | flat — long-tail unchanged |
+| B2 unique_frac | 0.873 | 0.887 | +1.5 pp — **no boilerplate change** |
+| B3 en_density_mean | 0.0244 | 0.0295 | **+21 %** |
+| B3 frac_above_05 | 0.198 | 0.241 | **+22 %** |
+| B3 frac_above_10 | 0.133 | 0.160 | **+20 %** |
+
+The pre-step row deliberately uses Oct/Nov 2022 — they bracket the step in time and
+are the slices with the closest sample sizes (~2.15 M docs) to the post-step
+slices (~2.0 M docs), so the comparison is not confounded by N.
+
+### Verdict
+
+The triple-signal pattern is: **B1 step DOWN (more short docs, long tail unchanged) +
+B3 step UP (more EN content) + B2 flat (no extra boilerplate)**. Mapping back to the
+ranked hypothesis set:
+
+- (A) extractor change: B1 fits, B3 unexpected for a pure extractor swap, B2 fits.
+  Partial match. Survives only if the extractor change is specifically
+  *"start retaining English-language results that were previously filtered."*
+- (B) Qwant ranking / index-expansion (Bing/EN syndication uptake): fits all three.
+  Search-result snippets are shorter (B1↓), Bing's index is EN-skewed (B3↑), and
+  each syndicated URL is content-unique (B2 flat). **Leading interpretation.**
+- (C) intra-batch release switchover: unfalsifiable from this evidence — any batch
+  boundary that draws from a different source distribution could produce all three.
+  Listed because it remains a viable mechanism, but the diagnostics don't actively
+  rule it out *or* in.
+
+Discriminating B vs C cleanly would need either (i) a per-doc TLD distribution
+(blocked: no URL field for pre-step slices), (ii) per-doc language classifier (≈10×
+B3 cost; ordering would have to be requested separately if needed), or (iii) the
+LongEval organizers confirming a release-batch boundary at Dec-2022 (cheapest path).
+
+### Note on B3 regex bug + fix
+
+The first B3 pass returned 0.0 for every slice. Cause: the regex `\b(the|and|...)\b`
+was assembled in Python and interpolated into a SQL expression via
+`F.expr("regexp_count(contents, '(?i)\\b...\\b')")`. Spark SQL string-literal parsing
+turns `\b` into the backspace character, so the regex never matched anything in
+normal text. Fix: use the Column API form `F.regexp_count(F.col("contents"),
+F.lit(raw_regex_string))`, which routes the regex string directly to the Pattern
+compiler without SQL escape processing. The fixed B3 ran in 12 min wall on the same
+hardware; results above. See `run_b3_fix.py` for the patched job.
+
+## Lineage / files used
+
+| What | Where |
+|---|---|
+| K=200 held-out topic proportions | `/mnt/data/tmp/lda-k200-converged/heldout/topic_proportions_15slice.parquet` |
+| K=200 topic words (200 × 100 terms) | `/mnt/data/tmp/lda-k200-converged/k200/topicWords_lda.txt` |
+| K=200 worklog + register pattern | [`20260527-lda-k200-worklog.md`](20260527-lda-k200-worklog.md) |
+| Cross-K saturation summary | [`20260528-lda-k-granularity-saturation.md`](20260528-lda-k-granularity-saturation.md) |
+| K=4 worklog (Finding #2: 100% FR labelled) | [`../acmiyaguchi/20260519-lda-k4-worklog.md`](../acmiyaguchi/20260519-lda-k4-worklog.md) |
+| Source parquets (no URL field) | `/mnt/data/tmp/longeval-{train,test}-parquet/Documents/...` |
+| Partial post-step URL mapping | `/mnt/fortis/clef-data/longeval/raw/id_urls_2023_{01,06,08}.txt` |
+| Aggregation pattern to reuse | `longeval/etl/parquet/tokens.py:36-56` (`TokenTask`) |
+| Diagnostic job (fused B1+B2+B3 + top-hashes) | `/mnt/data/tmp/corpus-diagnostics/run_diagnostics.py` |
+| B3 regex-bug fix job | `/mnt/data/tmp/corpus-diagnostics/run_b3_fix.py` |
+| Diagnostic CSVs | `/mnt/data/tmp/corpus-diagnostics/{doc-length,dedup,en-density}/summary_by_date.csv` |
+| Top-20 boilerplate hashes per slice | `/mnt/data/tmp/corpus-diagnostics/dedup/top_hashes_by_date.parquet` |


### PR DESCRIPTION
## Summary

Closes #36.

- Extend the default LDA sweep K grid to every integer K from 2 through 20.
- Keep `lda-topic-proportions` defaults aligned with the sweep grid.
- Make `TrainLDASweep` and `InferLDASweep` incremental by detecting completed per-K artifacts/stamps and only fitting/scoring missing Ks.
- Add regression tests for partial/missing-K detection.

## Validation

- `uv run ruff check longeval/etl/lda/workflow.py tests/lda_tests/test_workflow_sweep.py`
- `uv run pytest tests/lda_tests/test_workflow_sweep.py -q` — 21 passed

## Runtime validation

A full K=2..20 sweep is currently running against a fresh seeded root:

- input: `/mnt/data/tmp/longeval-train-parquet`
- output: `/mnt/data/tmp/lda-k2-20-sweep`
- params: `--date all --sample-fraction 1.0`

The root was hardlinked from the existing K=2..10 sweep, and preflight confirmed only K=11..20 were missing for train/inference while preprocess was complete.
